### PR TITLE
Support plugin reattachment

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -41,6 +41,46 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestClient_testInterface(t *testing.T) {
+	process := helperProcess("test-interface")
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+	})
+	defer c.Kill()
+
+	// Grab the RPC client
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	// Grab the impl
+	raw, err := client.Dispense("test")
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	impl, ok := raw.(testInterface)
+	if !ok {
+		t.Fatalf("bad: %#v", raw)
+	}
+
+	result := impl.Double(21)
+	if result != 42 {
+		t.Fatalf("bad: %#v", result)
+	}
+
+	// Kill it
+	c.Kill()
+
+	// Test that it knows it is exited
+	if !c.Exited() {
+		t.Fatal("should say client has exited")
+	}
+}
+
 func TestClient_cmdAndReattach(t *testing.T) {
 	config := &ClientConfig{
 		Cmd:      helperProcess("start-timeout"),

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -49,6 +50,82 @@ func TestClient_testInterface(t *testing.T) {
 		Plugins:         testPluginMap,
 	})
 	defer c.Kill()
+
+	// Grab the RPC client
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	// Grab the impl
+	raw, err := client.Dispense("test")
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	impl, ok := raw.(testInterface)
+	if !ok {
+		t.Fatalf("bad: %#v", raw)
+	}
+
+	result := impl.Double(21)
+	if result != 42 {
+		t.Fatalf("bad: %#v", result)
+	}
+
+	// Kill it
+	c.Kill()
+
+	// Test that it knows it is exited
+	if !c.Exited() {
+		t.Fatal("should say client has exited")
+	}
+}
+
+func TestClient_testInterfaceReattach(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no daemonization on Windows")
+		return
+	}
+
+	process := helperProcess("test-interface-daemon")
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+	})
+
+	// Start it so we can get the reattach info
+	if _, err := c.Start(); err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	// New client with reattach info
+	reattach := c.ReattachConfig()
+	if reattach == nil {
+		c.Kill()
+		t.Fatal("reattach config should be non-nil")
+	}
+
+	// Find the process and defer a kill so we know it is gone
+	p, err := os.FindProcess(reattach.Pid)
+	if err != nil {
+		c.Kill()
+		t.Fatalf("couldn't find process: %s", err)
+	}
+	defer p.Kill()
+
+	// Reattach
+	c = NewClient(&ClientConfig{
+		Reattach:        reattach,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+	})
+
+	// Start shouldn't error
+	if _, err := c.Start(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
 	// Grab the RPC client
 	client, err := c.Client()

--- a/client_test.go
+++ b/client_test.go
@@ -41,6 +41,21 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestClient_cmdAndReattach(t *testing.T) {
+	config := &ClientConfig{
+		Cmd:      helperProcess("start-timeout"),
+		Reattach: &ReattachConfig{},
+	}
+
+	c := NewClient(config)
+	defer c.Kill()
+
+	_, err := c.Start()
+	if err == nil {
+		t.Fatal("err should not be nil")
+	}
+}
+
 func TestClientStart_badVersion(t *testing.T) {
 	config := &ClientConfig{
 		Cmd:             helperProcess("bad-version"),

--- a/plugin_daemonize_unix_test.go
+++ b/plugin_daemonize_unix_test.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package plugin
+
+import (
+	"syscall"
+)
+
+func daemonize() {
+	syscall.Umask(0)
+}

--- a/plugin_daemonize_windows_test.go
+++ b/plugin_daemonize_windows_test.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package plugin
+
+func daemonize() {
+	panic("Not supported")
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -65,6 +65,11 @@ func (s *testInterfaceServer) Double(arg int, resp *int) error {
 	return nil
 }
 
+// testPluginMap can be used for tests as a plugin map
+var testPluginMap = map[string]Plugin{
+	"test": new(testInterfacePlugin),
+}
+
 func helperProcess(s ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestHelperProcess", "--"}
 	cs = append(cs, s...)
@@ -133,6 +138,14 @@ func TestHelperProcess(*testing.T) {
 		}
 
 		os.Exit(1)
+	case "test-interface":
+		Serve(&ServeConfig{
+			HandshakeConfig: testHandshake,
+			Plugins:         testPluginMap,
+		})
+
+		// Shouldn't reach here but make sure we exit anyways
+		os.Exit(0)
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %q\n", cmd)
 		os.Exit(2)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -147,6 +147,10 @@ func TestHelperProcess(*testing.T) {
 		// Shouldn't reach here but make sure we exit anyways
 		os.Exit(0)
 	case "test-interface-daemon":
+		// Daemonize
+		daemonize()
+
+		// Serve!
 		Serve(&ServeConfig{
 			HandshakeConfig: testHandshake,
 			Plugins:         testPluginMap,

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -146,6 +146,14 @@ func TestHelperProcess(*testing.T) {
 
 		// Shouldn't reach here but make sure we exit anyways
 		os.Exit(0)
+	case "test-interface-daemon":
+		Serve(&ServeConfig{
+			HandshakeConfig: testHandshake,
+			Plugins:         testPluginMap,
+		})
+
+		// Shouldn't reach here but make sure we exit anyways
+		os.Exit(0)
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %q\n", cmd)
 		os.Exit(2)


### PR DESCRIPTION
This adds support for reattaching to an already-running plugin process. 

To reattach, you ask the Client for the configuration with `ReattachConfig`. You then pass that into `NewClient` on subsequent calls and you can have multiple clients talking to the same plugin process. You can use `client.Kill` as normal to kill the process.

This is an advanced use case and puts some extra burden on the plugin host to maintain the reattach information and to also kill any zombie plugin processes if they're never reattached. 