### PR TITLE
Setting setsid for the plugin process

### DIFF
--- a/client.go
+++ b/client.go
@@ -335,6 +335,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = stderr_w
 	cmd.Stdout = stdout_w
+	c.isolateCmd(cmd)
 
 	log.Printf("[DEBUG] Starting plugin: %s %#v", cmd.Path, cmd.Args)
 	err = cmd.Start()

--- a/cmd_isolate_unix.go
+++ b/cmd_isolate_unix.go
@@ -1,0 +1,14 @@
+package plugin
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// isolateCmd sets the setid for the process
+func (c *Client) isolateCmd(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}

--- a/cmd_isolate_windows.go
+++ b/cmd_isolate_windows.go
@@ -1,0 +1,4 @@
+package plugin
+
+// TODO Not sure what needs to happen on windows
+func (c *Client) isolateCmd() {}


### PR DESCRIPTION
This isolates the plugin process from the process group of the plugin host and hence prevents the plugin and the sub-processes it launches to recieve interrupts that the plugin hosts receive. 

Although the plugin ignores any interrupts that it receives but it's sub-processes might not be designed to ignore interrupts.

For ex - When we launched a redis process using the plugin in Nomad, an interrupt to the Nomad client interrupted the redis process and the redis process died along with the Nomad client since it was still in the process group of the plugin host.