### PR TITLE
Fix windows process.

### DIFF
--- a/process_posix.go
+++ b/process_posix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package plugin
 
 import (

--- a/process_windows.go
+++ b/process_windows.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"os"
 	"syscall"
 )
 
@@ -22,8 +21,7 @@ func _pidAlive(pid int) bool {
 	}
 
 	var ec uint32
-	e = syscall.GetExitCodeProcess(h, &ec)
-	if e != nil {
+	if e := syscall.GetExitCodeProcess(h, &ec); e != nil {
 		return false
 	}
 


### PR DESCRIPTION
The windows process does not compile:

```
16:33:14 vendor\src\github.com\hashicorp\go-plugin\process_windows.go:4: imported and not used: "os"
16:33:14 vendor\src\github.com\hashicorp\go-plugin\process_windows.go:18: _pidAlive redeclared in this block
16:33:14 	previous declaration at vendor\src\github.com\hashicorp\go-plugin\process_posix.go:10
16:33:14 vendor\src\github.com\hashicorp\go-plugin\process_windows.go:25: undefined: e
16:33:14 vendor\src\github.com\hashicorp\go-plugin\process_windows.go:26: undefined: e
```

This change fixes those issues.

Signed-off-by: David Calavera <david.calavera@gmail.com>