### PR TITLE
client should attempt graceful quit

### DIFF
--- a/client.go
+++ b/client.go
@@ -243,8 +243,16 @@ func (c *Client) Kill() {
 		return
 	}
 
-	// Kill the process
-	c.process.Kill()
+	// Close the client to cleanly exit the process
+	client, err := c.Client()
+	if err == nil {
+		err = client.Close()
+	}
+	if err != nil {
+		// If something went wrong somewhere gracefully quitting the
+		// plugin, we just force kill it.
+		c.process.Kill()
+	}
 
 	// Wait for the client to finish logging so we have a complete log
 	<-c.doneLogging

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/rpc"
 	"os"
@@ -138,6 +139,24 @@ func TestHelperProcess(*testing.T) {
 		}
 
 		os.Exit(1)
+	case "cleanup":
+		// Create a defer to write the file. This tests that we get cleaned
+		// up properly versus just calling os.Exit
+		path := args[0]
+		defer func() {
+			err := ioutil.WriteFile(path, []byte("foo"), 0644)
+			if err != nil {
+				panic(err)
+			}
+		}()
+
+		Serve(&ServeConfig{
+			HandshakeConfig: testHandshake,
+			Plugins:         testPluginMap,
+		})
+
+		// Exit
+		return
 	case "test-interface":
 		Serve(&ServeConfig{
 			HandshakeConfig: testHandshake,


### PR DESCRIPTION
We were only calling process.Kill before which kills the process without
allowing it to perform any cleanup (defers are never called). This was
leaving around a lot of temporary files over time.

We now add a graceful quit method to the control stream that we attempt
to call first. If that fails, we still force quit, but at least this
gives the process a chance to gracefully exit.

🚧 **NOTE:** Don't merge this. I want to re-review this myself personally and make sure I'm happy with the way we're doing this. I posted this so @alex can review and test with Nomad.