### PR TITLE
client.Kill should check for addr before closing Client

### DIFF
--- a/plugin_test.go
+++ b/plugin_test.go
@@ -112,6 +112,15 @@ func TestHelperProcess(*testing.T) {
 	cmd, args := args[0], args[1:]
 	switch cmd {
 	case "bad-version":
+		// If we have an arg, we write there on start
+		if len(args) > 0 {
+			path := args[0]
+			err := ioutil.WriteFile(path, []byte("foo"), 0644)
+			if err != nil {
+				panic(err)
+			}
+		}
+
 		fmt.Printf("%d|%d1|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
 		<-make(chan int)
 	case "invalid-rpc-address":


### PR DESCRIPTION
This fixes an issue that Terraform users were seeing wit periodic hangs.
The unit test without this fix reproduces this hang.

This situation was caused when a plugin fails to start properly (invalid
RPC protocol version for example). In this case, `Start` sets `process`
since the binary started, but it never sets `address` because the plugin
is incompatible and never gets to serve an address.

When calling `Kill` in this situation, it wouldn't no-op since process
is set. Next, it'd call `Client` to get the client to close the
connection, but since `address` is nil Client would start the plugin
binary _again_. This would put the entire Client into a bad state and
would case Kill to fail and hang.

There are more bugs here for sure (not new ones introduced, just others
I found) but I want to fix this issue in isolation first.