### PR TITLE
Plugin Checksumming & TLS support 

### DIFF
--- a/client.go
+++ b/client.go
@@ -355,8 +355,8 @@ func (c *Client) Start() (addr net.Addr, err error) {
 			return nil, fmt.Errorf("Only one of Cmd or Reattach must be set")
 		}
 
-		if secureSet == attachSet {
-			return nil, fmt.Errorf("Only one of Cmd or SecureConfig can be set")
+		if secureSet && attachSet {
+			return nil, fmt.Errorf("Only one of Reattach or SecureConfig can be set")
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -141,7 +141,7 @@ type ReattachConfig struct {
 // SecureConfig is used to configure a client to verify the integrity of an
 // executable before running. It does this by verifying the checksum is
 // expected. Hash is used to specify the hashing method to use when checksumming
-// the file.  The configufation is verified by the client by calling the
+// the file.  The configuration is verified by the client by calling the
 // SecureConfig.Check() function.
 type SecureConfig struct {
 	Checksum []byte

--- a/client.go
+++ b/client.go
@@ -38,6 +38,9 @@ var (
 	// ErrProcessNotFound is returned when a client is instantiated to
 	// reattach to an existing process and it isn't found.
 	ErrProcessNotFound = errors.New("Reattachment process not found")
+	// ErrChecksumsDoNotMatch is returned when binary's checksum doesn't match
+	// the one provided in the SecureConfig.
+	ErrChecksumsDoNotMatch = errors.New("checksums did not match")
 )
 
 // Client handles the lifecycle of a plugin application. It launches
@@ -425,7 +428,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 		if ok, err := c.config.SecureConfig.Check(cmd.Path); err != nil {
 			return nil, err
 		} else if !ok {
-			return nil, errors.New("Checksums did not match")
+			return nil, ErrChecksumsDoNotMatch
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -330,7 +330,7 @@ func TestClient_Stdin(t *testing.T) {
 func TestClient_SecureConfig(t *testing.T) {
 	// Test failure case
 	secureConfig := &SecureConfig{
-		Checksum: []byte{},
+		Checksum: []byte{'1'},
 		Hash:     sha256.New(),
 	}
 	process := helperProcess("test-interface")

--- a/client_test.go
+++ b/client_test.go
@@ -453,3 +453,18 @@ func TestClient_TLS(t *testing.T) {
 		t.Fatal("should say client has exited")
 	}
 }
+
+func TestClient_secureConfigAndReattach(t *testing.T) {
+	config := &ClientConfig{
+		SecureConfig: &SecureConfig{},
+		Reattach:     &ReattachConfig{},
+	}
+
+	c := NewClient(config)
+	defer c.Kill()
+
+	_, err := c.Start()
+	if err != ErrSecureConfigAndReattach {
+		t.Fatal("err should not be %s, got %s", ErrSecureConfigAndReattach, err)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -322,5 +324,132 @@ func TestClient_Stdin(t *testing.T) {
 
 	if !process.ProcessState.Success() {
 		t.Fatal("process didn't exit cleanly")
+	}
+}
+
+func TestClient_SecureConfig(t *testing.T) {
+	// Test failure case
+	secureConfig := &SecureConfig{
+		Checksum: []byte{},
+		Hash:     sha256.New(),
+	}
+	process := helperProcess("test-interface")
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+		SecureConfig:    secureConfig,
+	})
+
+	// Grab the RPC client, should error
+	_, err := c.Client()
+	c.Kill()
+	if err != ErrChecksumsDoNotMatch {
+		t.Fatal("err should be %s, got %s", ErrChecksumsDoNotMatch, err)
+	}
+
+	// Get the checksum of the executable
+	file, err := os.Open(os.Args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sum := hash.Sum(nil)
+
+	secureConfig = &SecureConfig{
+		Checksum: sum,
+		Hash:     sha256.New(),
+	}
+
+	c = NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+		SecureConfig:    secureConfig,
+	})
+	defer c.Kill()
+
+	// Grab the RPC client
+	_, err = c.Client()
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+}
+
+func TestClient_TLS(t *testing.T) {
+	// Test failure case
+	process := helperProcess("test-interface-tls")
+	cBad := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+	})
+	defer cBad.Kill()
+
+	// Grab the RPC client
+	clientBad, err := cBad.Client()
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	// Grab the impl
+	raw, err := clientBad.Dispense("test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	cBad.Kill()
+
+	// Add TLS config to client
+	tlsConfig, err := helperTLSProvider()
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	process = helperProcess("test-interface-tls")
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+		TLSConfig:       tlsConfig,
+	})
+	defer c.Kill()
+
+	// Grab the RPC client
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	// Grab the impl
+	raw, err = client.Dispense("test")
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	impl, ok := raw.(testInterface)
+	if !ok {
+		t.Fatalf("bad: %#v", raw)
+	}
+
+	result := impl.Double(21)
+	if result != 42 {
+		t.Fatalf("bad: %#v", result)
+	}
+
+	// Kill it
+	c.Kill()
+
+	// Test that it knows it is exited
+	if !c.Exited() {
+		t.Fatal("should say client has exited")
 	}
 }

--- a/server.go
+++ b/server.go
@@ -49,6 +49,7 @@ type ServeConfig struct {
 	// Plugins are the plugins that are served.
 	Plugins map[string]Plugin
 
+	// TLSProvider is a function that returns a configured tls.Config.
 	TLSProvider func() (*tls.Config, error)
 }
 

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -47,6 +48,8 @@ type ServeConfig struct {
 
 	// Plugins are the plugins that are served.
 	Plugins map[string]Plugin
+
+	TLSProvider func() (*tls.Config, error)
 }
 
 // Serve serves the plugins given by ServeConfig.
@@ -95,6 +98,15 @@ func Serve(opts *ServeConfig) {
 	if err != nil {
 		log.Printf("[ERR] plugin: plugin init: %s", err)
 		return
+	}
+
+	if opts.TLSProvider != nil {
+		tlsConfig, err := opts.TLSProvider()
+		if err != nil {
+			log.Printf("[ERR] plugin: plugin tls init: %s", err)
+			return
+		}
+		listener = tls.NewListener(listener, tlsConfig)
 	}
 	defer listener.Close()
 


### PR DESCRIPTION
This PR adds support for verifying the integrity of a plugin by matching the binary's checksum with an expected checksum. It introduces the notion of a `SecureConfig` which stores the expected checksum and selected hashing method.

It also adds support for providing a TLS config to both the client and server of a plugin. 