### PR TITLE
RPCClient supports Ping to check plugin connection health

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -468,3 +468,30 @@ func TestClient_secureConfigAndReattach(t *testing.T) {
 		t.Fatal("err should not be %s, got %s", ErrSecureConfigAndReattach, err)
 	}
 }
+
+func TestClient_ping(t *testing.T) {
+	process := helperProcess("test-interface")
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+	})
+	defer c.Kill()
+
+	// Get the client
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Ping, should work
+	if err := client.Ping(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Kill it
+	c.Kill()
+	if err := client.Ping(); err == nil {
+		t.Fatal("should error")
+	}
+}

--- a/rpc_client.go
+++ b/rpc_client.go
@@ -121,3 +121,13 @@ func (c *RPCClient) Dispense(name string) (interface{}, error) {
 
 	return p.Client(c.broker, rpc.NewClient(conn))
 }
+
+// Ping pings the connection to ensure it is still alive.
+//
+// The error from the RPC call is returned exactly if you want to inspect
+// it for further error analysis. Any error returned from here would indicate
+// that the connection to the plugin is not healthy.
+func (c *RPCClient) Ping() error {
+	var empty struct{}
+	return c.control.Call("Control.Ping", true, &empty)
+}

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -122,6 +122,14 @@ type controlServer struct {
 	server *RPCServer
 }
 
+// Ping can be called to verify the connection (and likely the binary)
+// is still alive to a plugin.
+func (c *controlServer) Ping(
+	null bool, response *struct{}) error {
+	*response = struct{}{}
+	return nil
+}
+
 func (c *controlServer) Quit(
 	null bool, response *struct{}) error {
 	// End the server


### PR DESCRIPTION
There was no easy way that a plugin consumer could easily check the health of a plugin connection. This is a simple Ping method to do that.