### PR TITLE
Client logging

### DIFF
--- a/client.go
+++ b/client.go
@@ -740,9 +740,9 @@ func (c *Client) logStderr(r io.Reader) {
 			line = strings.TrimRightFunc(line, unicode.IsSpace)
 
 			l := c.logger.Named(filepath.Base(c.config.Cmd.Path))
-			// If output is not JSON format, print directly as error
+			// If output is not JSON format, print directly to Debug
 			if !isJSON(line) {
-				l.Debug("log from plugin", "entry", line)
+				l.Debug(line)
 			} else {
 				// Parse JSON line received from the plugin into logEntry, and print via
 				// the client's logger

--- a/client.go
+++ b/client.go
@@ -271,8 +271,11 @@ func NewClient(config *ClientConfig) (c *Client) {
 	}
 
 	if config.Logger == nil {
-		config.Logger = hclog.Default()
-		config.Logger = config.Logger.ResetNamed("plugin")
+		config.Logger = hclog.New(&hclog.LoggerOptions{
+			Output: hclog.DefaultOutput,
+			Level:  hclog.Trace,
+			Name:   "plugin",
+		})
 	}
 
 	c = &Client{


### PR DESCRIPTION
We worked around this in Terraform, but I'm proposing this change upstream since it did break legacy behavior of programs updating the go-plugins package.

The legacy behavior for go-plugin was to log everything to the
default log output. The default hclog.Logger has a log level of Info, so
clients that have not updated to provide a custom Logger no longer will
see any output from the plugins.

This updates the default Logger to Trace, so that all output is still
seen by clients

The second commit reduces the verbosity of the plugin stderr output lines. The Logger is already being named "plugin" so the "log from plugin" message is redundant, and we can pass the rest of the unstructured data through as-is, again better preserving the legacy behavior.  