### PR TITLE
Fix json detection for log entries

### DIFF
--- a/client.go
+++ b/client.go
@@ -778,6 +778,6 @@ func (c *Client) logStderr(r io.Reader) {
 }
 
 func isJSON(str string) bool {
-	var js json.RawMessage
+	var js map[string]interface{}
 	return json.Unmarshal([]byte(str), &js) == nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -47,6 +47,23 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestClient_isJSON(t *testing.T) {
+	shouldBeFalse := isJSON(`["data1", "data2"]`)
+	if shouldBeFalse {
+		t.Fatal("isJSON() should return false when entry is not a {} json object.")
+	}
+
+	shouldBeFalse = isJSON("some text")
+	if shouldBeFalse {
+		t.Fatal("isJson() should return false when entry is simple text.")
+	}
+
+	shouldBeTrue := isJSON(`{"key1": "data1", "key2": "data2"}`)
+	if !shouldBeTrue {
+		t.Fatal("isJSON() should return true when entry is a {} json object.")
+	}
+}
+
 // This tests a bug where Kill would start
 func TestClient_killStart(t *testing.T) {
 	// Create a temporary dir to store the result file


### PR DESCRIPTION
When you have a log entry from the plugin with this kind of format `["elem1", "elem2"]` the actual json detection will detect that it's valid json format (which is actually correct) but the function [parseJSON](https://github.com/hashicorp/go-plugin/blob/master/log_entry.go#L36) expect that the json follow the interface `map[string]interface{}`. 

Obviously, an json array doesn't follow this kind of interface. My little fix is here to detect if the json follow the json object format and not the json array format (replace `json.RawMessage` by `map[string]interface{}` in `isJSON` function)