### PR TITLE
Invalid JSON on stderr crashes Client

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -516,6 +516,33 @@ func TestClient_Stderr(t *testing.T) {
 	}
 }
 
+func TestClient_StderrJSON(t *testing.T) {
+	stderr := new(bytes.Buffer)
+	process := helperProcess("stderr-json")
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		Stderr:          stderr,
+		HandshakeConfig: testHandshake,
+	})
+	defer c.Kill()
+
+	if _, err := c.Start(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	for !c.Exited() {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !strings.Contains(stderr.String(), "[\"HELLO\"]\n") {
+		t.Fatalf("bad log data: '%s'", stderr.String())
+	}
+
+	if !strings.Contains(stderr.String(), "12345\n") {
+		t.Fatalf("bad log data: '%s'", stderr.String())
+	}
+}
+
 func TestClient_Stdin(t *testing.T) {
 	// Overwrite stdin for this test with a temporary file
 	tf, err := ioutil.TempFile("", "terraform")

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -278,8 +278,13 @@ func TestHelperProcess(*testing.T) {
 		os.Exit(1)
 	case "stderr":
 		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
-		log.Println("HELLO")
-		log.Println("WORLD")
+		os.Stderr.WriteString("HELLO\n")
+		os.Stderr.WriteString("WORLD\n")
+	case "stderr-json":
+		// write values that might be JSON, but aren't KVs
+		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
+		os.Stderr.WriteString("[\"HELLO\"]\n")
+		os.Stderr.WriteString("12345\n")
 	case "stdin":
 		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
 		data := make([]byte, 5)


### PR DESCRIPTION
The isJSON checked if the output was valid json of any type, but the
logger only unmarshaled into `map[string]interface{}`. If the line
didn't umarshal correctly, the error was only logged, but the actual
line was lost and the loop continued into a nil pointer dereference.

Always log the raw line if it can't unmarshal into a map.

Fixes https://github.com/hashicorp/terraform/issues/15822