### PR TITLE
Fix small typo in gRPC plugin error message

### DIFF
--- a/grpc_server.go
+++ b/grpc_server.go
@@ -79,7 +79,7 @@ func (s *GRPCServer) Init() error {
 	for k, raw := range s.Plugins {
 		p, ok := raw.(GRPCPlugin)
 		if !ok {
-			return fmt.Errorf("%q is not a GRPC-compatibile plugin", k)
+			return fmt.Errorf("%q is not a GRPC-compatible plugin", k)
 		}
 
 		if err := p.GRPCServer(s.broker, s.server); err != nil {


### PR DESCRIPTION
Small cosmetic fix.

For what its worth, I couldn't build or run the tests because there's no vendor dir and there doesn't seem to be any dep management, so I was missing some stuff.