### PR TITLE
Remove "log" package

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"hash"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"os/exec"
@@ -234,7 +233,6 @@ func CleanupClients() {
 	}
 	managedClientsLock.Unlock()
 
-	log.Println("[DEBUG] plugin: waiting for all plugin processes to complete...")
 	wg.Wait()
 }
 


### PR DESCRIPTION
Fixes #44 

Remove the last usage of the standard `log` package so we're all `hclog` now.

This removes a log statement that isn't recreated anywhere else. I tried putting the statements into `client.Kill` but it gets pretty noisy. I also realized that clients aren't named right now so if you launch a bunch of plugins you invariably get a lot of untargeted "Kill requested" type logs which aren't helpful.

I think it may be better to just remove this for now.