### PR TITLE
Make the tests pass the race detector

### DIFF
--- a/rpc_client_test.go
+++ b/rpc_client_test.go
@@ -24,7 +24,7 @@ func TestClient_App(t *testing.T) {
 
 	client, _ := TestPluginRPCConn(t, map[string]Plugin{
 		"test": &testInterfacePlugin{Impl: testPlugin},
-	})
+	}, nil)
 	defer client.Close()
 
 	raw, err := client.Dispense("test")
@@ -48,10 +48,10 @@ func TestClient_syncStreams(t *testing.T) {
 	stdout_r, stdout_w := io.Pipe()
 	stderr_r, stderr_w := io.Pipe()
 
-	TestPluginStdout = stdout_r
-	TestPluginStderr = stderr_r
-
-	client, _ := TestPluginRPCConn(t, map[string]Plugin{})
+	client, _ := TestPluginRPCConn(t, map[string]Plugin{}, &TestOptions{
+		ServerStdout: stdout_r,
+		ServerStderr: stderr_r,
+	})
 
 	// Start the data copying
 	var stdout_out, stderr_out safeBuffer

--- a/testing.go
+++ b/testing.go
@@ -3,11 +3,17 @@ package plugin
 import (
 	"bytes"
 	"context"
+	"io"
 	"net"
 	"net/rpc"
 
 	"github.com/mitchellh/go-testing-interface"
 	"google.golang.org/grpc"
+)
+
+var (
+	TestPluginStdout io.ReadCloser
+	TestPluginStderr io.ReadCloser
 )
 
 // The testing file contains test helpers that you can use outside of
@@ -67,6 +73,12 @@ func TestPluginRPCConn(t testing.T, ps map[string]Plugin) (*RPCClient, *RPCServe
 
 	// Start up the server
 	server := &RPCServer{Plugins: ps, Stdout: new(bytes.Buffer), Stderr: new(bytes.Buffer)}
+	if TestPluginStdout != nil {
+		server.Stdout = TestPluginStdout
+	}
+	if TestPluginStderr != nil {
+		server.Stderr = TestPluginStderr
+	}
 	go server.ServeConn(serverConn)
 
 	// Connect the client to the server

--- a/testing.go
+++ b/testing.go
@@ -11,8 +11,15 @@ import (
 	"google.golang.org/grpc"
 )
 
+// TestOptions allows specifying options that can affect the behavior of the
+// test functions
 type TestOptions struct {
+	//ServerStdout causes the given value to be used in place of a blank buffer
+	//for RPCServer's Stdout
 	ServerStdout io.ReadCloser
+
+	//ServerStderr causes the given value to be used in place of a blank buffer
+	//for RPCServer's Stderr
 	ServerStderr io.ReadCloser
 }
 

--- a/testing.go
+++ b/testing.go
@@ -11,10 +11,10 @@ import (
 	"google.golang.org/grpc"
 )
 
-var (
-	TestPluginStdout io.ReadCloser
-	TestPluginStderr io.ReadCloser
-)
+type TestOptions struct {
+	ServerStdout io.ReadCloser
+	ServerStderr io.ReadCloser
+}
 
 // The testing file contains test helpers that you can use outside of
 // this package for making it easier to test plugins themselves.
@@ -67,17 +67,19 @@ func TestRPCConn(t testing.T) (*rpc.Client, *rpc.Server) {
 
 // TestPluginRPCConn returns a plugin RPC client and server that are connected
 // together and configured.
-func TestPluginRPCConn(t testing.T, ps map[string]Plugin) (*RPCClient, *RPCServer) {
+func TestPluginRPCConn(t testing.T, ps map[string]Plugin, opts *TestOptions) (*RPCClient, *RPCServer) {
 	// Create two net.Conns we can use to shuttle our control connection
 	clientConn, serverConn := TestConn(t)
 
 	// Start up the server
 	server := &RPCServer{Plugins: ps, Stdout: new(bytes.Buffer), Stderr: new(bytes.Buffer)}
-	if TestPluginStdout != nil {
-		server.Stdout = TestPluginStdout
-	}
-	if TestPluginStderr != nil {
-		server.Stderr = TestPluginStderr
+	if opts != nil {
+		if opts.ServerStdout != nil {
+			server.Stdout = opts.ServerStdout
+		}
+		if opts.ServerStderr != nil {
+			server.Stderr = opts.ServerStderr
+		}
 	}
 	go server.ServeConn(serverConn)
 


### PR DESCRIPTION
These changes are relatively obvious; the one that might cause a little
heartburn is declaring a package-level variable for test stdout/err, but
given the control flow of the test functions it's either that or modify
the test function APIs. I'm happy to do the latter if it's deemed to not
be a big deal, since they're test functions.