### PR TITLE
fix broken GRPC bidirectional example

### DIFF
--- a/examples/bidirectional/main.go
+++ b/examples/bidirectional/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-plugin/examples/grpc-bidirectional/shared"
+	"github.com/hashicorp/go-plugin/examples/bidirectional/shared"
 )
 
 type addHelper struct{}

--- a/examples/bidirectional/plugin-go-grpc/main.go
+++ b/examples/bidirectional/plugin-go-grpc/main.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-plugin/examples/grpc-bidirectional/shared"
+	"github.com/hashicorp/go-plugin/examples/bidirectional/shared"
 )
 
 // Here is a real implementation of KV that writes to a local file with

--- a/examples/bidirectional/shared/grpc.go
+++ b/examples/bidirectional/shared/grpc.go
@@ -3,7 +3,7 @@ package shared
 import (
 	hclog "github.com/hashicorp/go-hclog"
 	plugin "github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-plugin/examples/grpc-bidirectional/proto"
+	"github.com/hashicorp/go-plugin/examples/bidirectional/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )

--- a/examples/bidirectional/shared/interface.go
+++ b/examples/bidirectional/shared/interface.go
@@ -2,10 +2,11 @@
 package shared
 
 import (
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-plugin/examples/grpc-bidirectional/proto"
+	"github.com/hashicorp/go-plugin/examples/bidirectional/proto"
 )
 
 // Handshake is a common handshake that is shared by plugin and host.
@@ -48,7 +49,7 @@ func (p *CounterPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) er
 	return nil
 }
 
-func (p *CounterPlugin) GRPCClient(broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (p *CounterPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
 	return &GRPCClient{
 		client: proto.NewCounterClient(c),
 		broker: broker,


### PR DESCRIPTION
This PR fixes the GRPC bidirectional example in examples/. The import paths were wrong and  the plugin.GRPCPlugin interface was not implemented properly thus the example was not usable as documented in the README.