### PR TITLE
client: reuse the same logger

### DIFF
--- a/client.go
+++ b/client.go
@@ -751,13 +751,13 @@ func (c *Client) dialer(_ string, timeout time.Duration) (net.Conn, error) {
 
 func (c *Client) logStderr(r io.Reader) {
 	bufR := bufio.NewReader(r)
+	l := c.logger.Named(filepath.Base(c.config.Cmd.Path))
+
 	for {
 		line, err := bufR.ReadString('\n')
 		if line != "" {
 			c.config.Stderr.Write([]byte(line))
 			line = strings.TrimRightFunc(line, unicode.IsSpace)
-
-			l := c.logger.Named(filepath.Base(c.config.Cmd.Path))
 
 			entry, err := parseJSON(line)
 			// If output is not JSON format, print directly to Debug
@@ -766,7 +766,7 @@ func (c *Client) logStderr(r io.Reader) {
 			} else {
 				out := flattenKVPairs(entry.KVPairs)
 
-				l = l.With("timestamp", entry.Timestamp.Format(hclog.TimeFormat))
+				out = append(out, "timestamp", entry.Timestamp.Format(hclog.TimeFormat))
 				switch hclog.LevelFromString(entry.Level) {
 				case hclog.Trace:
 					l.Trace(entry.Message, out...)


### PR DESCRIPTION
The race detector was complaining about these lines, and it's more performant to not create a new logger for each log line. 

I'm not sure why we need to explicitly add the timestamp to the log arguments, but I left it incase something is using it. 