### PR TITLE
Reconnect Logic and built-in support for bi-directional comm over go/rpc

### DIFF
--- a/examples/rpc/README.md
+++ b/examples/rpc/README.md
@@ -1,0 +1,11 @@
+# RPC Plugin Example
+
+This example shows the use of go-plugin
+
+- Adds Restart Value to client config that will cause a plugin to be restarted if it exits
+- Simplifies Bidirectional Communication by adding Serve(..) to client and Dispense(..) to server
+
+To run build rpc/examples/extension.go and build/run host.go
+
+Alternatively install go-task "go get -u -v github.com/go-task/task/cmd/task"
+and run "task example" from this folder

--- a/examples/rpc/Taskfile.yml
+++ b/examples/rpc/Taskfile.yml
@@ -1,0 +1,11 @@
+version: '2'
+# install go task "go get -u -v github.com/go-task/task/cmd/task"
+# run "task example"
+
+tasks:
+  test:
+    cmds:
+      - go test ./...
+  example:
+    cmds:
+      - cd ./examples && task run

--- a/examples/rpc/api/extender.go
+++ b/examples/rpc/api/extender.go
@@ -1,0 +1,5 @@
+package api
+
+type Extender interface {
+	HelloExtension(string) error
+}

--- a/examples/rpc/api/handshake.go
+++ b/examples/rpc/api/handshake.go
@@ -1,0 +1,9 @@
+package api
+
+import plugin "gitlab.com/indis/libs/third_party/go-plugin"
+
+var Handshake = plugin.HandshakeConfig{
+	ProtocolVersion:  1,
+	MagicCookieKey:   "PLUGGER",
+	MagicCookieValue: "PLUGIT",
+}

--- a/examples/rpc/api/handshake.go
+++ b/examples/rpc/api/handshake.go
@@ -1,6 +1,6 @@
 package api
 
-import plugin "gitlab.com/indis/libs/third_party/go-plugin"
+import plugin "github.com/sampaioletti/go-plugin/examples/go-plugin"
 
 var Handshake = plugin.HandshakeConfig{
 	ProtocolVersion:  1,

--- a/examples/rpc/api/host.go
+++ b/examples/rpc/api/host.go
@@ -1,0 +1,5 @@
+package api
+
+type Host interface {
+	HelloHost(string) error
+}

--- a/examples/rpc/examples/Taskfile.yml
+++ b/examples/rpc/examples/Taskfile.yml
@@ -1,0 +1,14 @@
+version: '2'
+# install go task "go get -u -v github.com/go-task/task/cmd/task"
+# run "task run"
+
+tasks:
+  build:
+    cmds:
+      - cd ./extension && go build .
+
+  run:
+    deps: 
+      - build
+    cmds:
+      - go run host.go

--- a/examples/rpc/examples/extension/extension.go
+++ b/examples/rpc/examples/extension/extension.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"gitlab.com/indis/libs/extension/api"
+	"gitlab.com/indis/libs/extension/pkg/server"
+	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+)
+
+func main() {
+	hclog.DefaultOptions = &hclog.LoggerOptions{
+		Name:   "extension",
+		Output: os.Stderr,
+		Level:  hclog.Info,
+	}
+	logger := hclog.L()
+	logger.Info("Started Extension")
+	cfg := &plugin.ServeConfig{
+		HandshakeConfig: api.Handshake,
+		Plugins: map[string]plugin.Plugin{
+			"extension": &server.RPC{Impl: &server.Extension{}},
+		},
+		AcceptPlugins: map[string]plugin.Plugin{
+			"host": &server.RPC{},
+		},
+		Logger: logger,
+	}
+
+	done, c, err := plugin.ServeAndDispense(cfg)
+	if err != nil {
+		logger.Debug(err.Error())
+	}
+	time.Sleep(time.Second * 5)
+	raw, err := c.Dispense("host")
+	if err != nil {
+		logger.Debug(err.Error())
+	}
+	if host, ok := raw.(api.Host); ok {
+		go func() {
+			ch := time.NewTicker(time.Second * 5).C
+			for {
+				select {
+				case <-ch:
+					if err := host.HelloHost("Hello From Extension"); err != nil {
+						logger.Debug(err.Error())
+					}
+				}
+			}
+
+		}()
+	}
+	<-done
+}

--- a/examples/rpc/examples/extension/extension.go
+++ b/examples/rpc/examples/extension/extension.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
-	"gitlab.com/indis/libs/extension/api"
-	"gitlab.com/indis/libs/extension/pkg/server"
-	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+	"github.com/sampaioletti/go-plugin/examples/api"
+	plugin "github.com/sampaioletti/go-plugin/examples/go-plugin"
+	"github.com/sampaioletti/go-plugin/examples/pkg/server"
 )
 
 func main() {

--- a/examples/rpc/examples/host.go
+++ b/examples/rpc/examples/host.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"gitlab.com/indis/libs/extension/api"
-	"gitlab.com/indis/libs/extension/pkg/client"
-	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+	"github.com/sampaioletti/go-plugin/examples/api"
+	plugin "github.com/sampaioletti/go-plugin/examples/go-plugin"
+	"github.com/sampaioletti/go-plugin/examples/pkg/client"
 )
 
 func main() {

--- a/examples/rpc/examples/host.go
+++ b/examples/rpc/examples/host.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"gitlab.com/indis/libs/extension/api"
+	"gitlab.com/indis/libs/extension/pkg/client"
+	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+)
+
+func main() {
+	hclog.DefaultOptions = &hclog.LoggerOptions{
+		Name:   "plugin",
+		Output: os.Stdout,
+		Level:  hclog.Debug,
+	}
+	logger := hclog.L()
+	logger.Info("Host Started")
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig: api.Handshake,
+		Plugins: map[string]plugin.Plugin{
+			"extension": &client.RPC{},
+		},
+		ServedPlugins: map[string]plugin.Plugin{
+			"host": &client.RPC{},
+		},
+		Cmd:       exec.Command("./extension/extension"),
+		Logger:    logger,
+		Managed:   true,
+		Reconnect: true,
+	})
+	defer client.Kill()
+	// Connect via RPC
+	rpcClient, err := client.Client()
+	if err != nil {
+		logger.Debug(err.Error())
+		panic(0)
+	}
+
+	raw, err := rpcClient.Dispense("extension")
+	if err != nil {
+		logger.Debug(err.Error())
+		panic(0)
+	}
+
+	if ext, ok := raw.(api.Extender); ok {
+		go func() {
+			ch := time.NewTicker(time.Second * 5).C
+			for {
+				select {
+				case <-ch:
+					if err := ext.HelloExtension("Hello From Host"); err != nil {
+						logger.Debug(err.Error())
+					}
+				}
+			}
+
+		}()
+	}
+	time.Sleep(time.Second * 1)
+	done, err := client.Serve()
+	if err != nil {
+		logger.Debug(err.Error())
+		panic(0)
+	}
+	<-done
+}

--- a/examples/rpc/pkg/client/client.go
+++ b/examples/rpc/pkg/client/client.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	hclog "github.com/hashicorp/go-hclog"
-	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+	plugin "github.com/sampaioletti/go-plugin/examples/go-plugin"
 )
 
 var _ plugin.Plugin = (*RPC)(nil)

--- a/examples/rpc/pkg/client/client.go
+++ b/examples/rpc/pkg/client/client.go
@@ -1,0 +1,92 @@
+package client
+
+import (
+	hclog "github.com/hashicorp/go-hclog"
+	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+)
+
+var _ plugin.Plugin = (*RPC)(nil)
+
+type RPC struct {
+	Impl   *Host
+	logger hclog.Logger
+	// rpc    plugin.ClientProtocol
+	// Plugin *plugin.Client
+	//Extension api.Extender
+	// name string
+}
+
+func (c *RPC) Client(broker *plugin.MuxBroker, client *plugin.RPCConnection) (interface{}, error) {
+	return &ExtClient{broker, client}, nil
+}
+
+func (s *RPC) Server(b *plugin.MuxBroker) (interface{}, error) {
+	return &HostServer{s.Impl, b}, nil
+}
+
+// func (r *RPC) FindAndDispenseExt(name string) (api.Extender, error) {
+// 	r.name = name
+// 	pluginLogger := r.logger.Named(name)
+// 	files, err := Discover(name, r.logger)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	for _, v := range files {
+
+// 		r.logger.Debug("Creating", "path", v)
+// 		var cl plugin.ClientProtocol
+// 		if r.Plugin == nil {
+// 			r.Plugin = r.newClient(v, pluginLogger)
+// 		} else {
+// 			r.Plugin.Config.Cmd = exec.Command(v)
+// 			r.Plugin.Config.Logger = pluginLogger
+// 		}
+// 		r.Plugin = r.newClient(v, pluginLogger)
+// 		cl, err = r.Plugin.Client()
+// 		if err != nil {
+// 			if cl != nil {
+// 				cl.Close()
+// 			}
+// 			r.logger.Debug(err.Error(), "file", v)
+// 			continue
+// 		}
+// 		r.rpc = cl
+// 		r.logger.Debug("client created", "client", cl, "err", err)
+// 		var raw interface{}
+// 		r.logger.Debug("Dispensing")
+// 		raw, err = cl.Dispense("plugin")
+// 		if err != nil {
+// 			r.logger.Debug(err.Error(), "file", v)
+// 			cl.Close()
+// 			continue
+// 		}
+// 		pl, ok := raw.(api.Extender)
+// 		if !ok {
+// 			cl.Close()
+// 			err = errors.New("Not of Type Plugin")
+// 			r.logger.Debug(err.Error(), "file", v)
+// 			continue
+// 		}
+
+// 		r.logger.Debug("Plugin Started")
+// 		return pl, nil
+// 	}
+// 	return nil, err
+// }
+
+// func (r *RPC) newClient(p string, logger hclog.Logger) *plugin.Client {
+// 	return plugin.NewClient(&plugin.ClientConfig{
+// 		HandshakeConfig: api.Handshake,
+// 		Plugins:         map[string]plugin.Plugin{"plugin": r},
+// 		Cmd:             exec.Command(p),
+// 		Logger:          logger,
+// 		Managed:         true,
+// 		Reconnect:       true,
+// 	})
+// }
+// func (r *RPC) Close() error {
+// 	if r.Plugin != nil {
+// 		r.Plugin.Kill()
+// 	}
+// 	return nil
+// }

--- a/examples/rpc/pkg/client/client.go
+++ b/examples/rpc/pkg/client/client.go
@@ -10,10 +10,6 @@ var _ plugin.Plugin = (*RPC)(nil)
 type RPC struct {
 	Impl   *Host
 	logger hclog.Logger
-	// rpc    plugin.ClientProtocol
-	// Plugin *plugin.Client
-	//Extension api.Extender
-	// name string
 }
 
 func (c *RPC) Client(broker *plugin.MuxBroker, client *plugin.RPCConnection) (interface{}, error) {
@@ -23,70 +19,3 @@ func (c *RPC) Client(broker *plugin.MuxBroker, client *plugin.RPCConnection) (in
 func (s *RPC) Server(b *plugin.MuxBroker) (interface{}, error) {
 	return &HostServer{s.Impl, b}, nil
 }
-
-// func (r *RPC) FindAndDispenseExt(name string) (api.Extender, error) {
-// 	r.name = name
-// 	pluginLogger := r.logger.Named(name)
-// 	files, err := Discover(name, r.logger)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	for _, v := range files {
-
-// 		r.logger.Debug("Creating", "path", v)
-// 		var cl plugin.ClientProtocol
-// 		if r.Plugin == nil {
-// 			r.Plugin = r.newClient(v, pluginLogger)
-// 		} else {
-// 			r.Plugin.Config.Cmd = exec.Command(v)
-// 			r.Plugin.Config.Logger = pluginLogger
-// 		}
-// 		r.Plugin = r.newClient(v, pluginLogger)
-// 		cl, err = r.Plugin.Client()
-// 		if err != nil {
-// 			if cl != nil {
-// 				cl.Close()
-// 			}
-// 			r.logger.Debug(err.Error(), "file", v)
-// 			continue
-// 		}
-// 		r.rpc = cl
-// 		r.logger.Debug("client created", "client", cl, "err", err)
-// 		var raw interface{}
-// 		r.logger.Debug("Dispensing")
-// 		raw, err = cl.Dispense("plugin")
-// 		if err != nil {
-// 			r.logger.Debug(err.Error(), "file", v)
-// 			cl.Close()
-// 			continue
-// 		}
-// 		pl, ok := raw.(api.Extender)
-// 		if !ok {
-// 			cl.Close()
-// 			err = errors.New("Not of Type Plugin")
-// 			r.logger.Debug(err.Error(), "file", v)
-// 			continue
-// 		}
-
-// 		r.logger.Debug("Plugin Started")
-// 		return pl, nil
-// 	}
-// 	return nil, err
-// }
-
-// func (r *RPC) newClient(p string, logger hclog.Logger) *plugin.Client {
-// 	return plugin.NewClient(&plugin.ClientConfig{
-// 		HandshakeConfig: api.Handshake,
-// 		Plugins:         map[string]plugin.Plugin{"plugin": r},
-// 		Cmd:             exec.Command(p),
-// 		Logger:          logger,
-// 		Managed:         true,
-// 		Reconnect:       true,
-// 	})
-// }
-// func (r *RPC) Close() error {
-// 	if r.Plugin != nil {
-// 		r.Plugin.Kill()
-// 	}
-// 	return nil
-// }

--- a/examples/rpc/pkg/client/discover.go
+++ b/examples/rpc/pkg/client/discover.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func Discover(name string) ([]string, error) {
+	fileGlob := fmt.Sprintf("%s*", name)
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		return nil, err
+	}
+
+	//look for plugins in current directory and subfolders
+	var files []string
+	filesSub, err := filepath.Glob(filepath.Join(dir, "**/", fileGlob))
+	filesCurrent, err := filepath.Glob(filepath.Join(dir, fileGlob))
+	files = append(filesSub, filesCurrent...)
+
+	//Look for files in system directories
+	pathFile, err := exec.LookPath(name)
+	if err != nil && len(pathFile) > 0 {
+		files = append(files, pathFile)
+	}
+
+	// Test for Executable using exec.Lookpath, remove Extensions first as LookPath matches extension if included
+	exeFiles := []string{}
+	for _, v := range files {
+		p := ""
+		p, err = exec.LookPath(strings.TrimSuffix(v, filepath.Ext(v)))
+		if err != nil {
+			continue
+		}
+		exeFiles = append(exeFiles, p)
+
+	}
+	if len(files) < 1 {
+		return nil, errors.New("No Plugins found")
+	}
+
+	return files, nil
+}

--- a/examples/rpc/pkg/client/extClient.go
+++ b/examples/rpc/pkg/client/extClient.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"gitlab.com/indis/libs/extension/api"
-	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+	"github.com/sampaioletti/go-plugin/examples/api"
+	plugin "github.com/sampaioletti/go-plugin/examples/go-plugin"
 )
 
 var _ api.Extender = (*ExtClient)(nil)

--- a/examples/rpc/pkg/client/extClient.go
+++ b/examples/rpc/pkg/client/extClient.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"gitlab.com/indis/libs/extension/api"
+	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+)
+
+var _ api.Extender = (*ExtClient)(nil)
+
+type ExtClient struct {
+	broker *plugin.MuxBroker
+	client *plugin.RPCConnection
+}
+
+func (s *ExtClient) HelloExtension(name string) error {
+	var rErr error
+	lErr := s.client.Call("Plugin.HelloExtension", name, &rErr)
+	if lErr != nil {
+		return lErr
+	}
+	if rErr != nil {
+		return rErr
+	}
+	return nil
+}

--- a/examples/rpc/pkg/client/host.go
+++ b/examples/rpc/pkg/client/host.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	hclog "github.com/hashicorp/go-hclog"
-	"gitlab.com/indis/libs/extension/api"
+	"github.com/sampaioletti/go-plugin/examples/api"
 )
 
 var _ api.Host = (*Host)(nil)

--- a/examples/rpc/pkg/client/host.go
+++ b/examples/rpc/pkg/client/host.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	hclog "github.com/hashicorp/go-hclog"
+	"gitlab.com/indis/libs/extension/api"
+)
+
+var _ api.Host = (*Host)(nil)
+
+type Host struct {
+}
+
+func (p *Host) HelloHost(hello string) error {
+	hclog.L().Info(hello)
+	return nil
+}

--- a/examples/rpc/pkg/client/hostServer.go
+++ b/examples/rpc/pkg/client/hostServer.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+)
+
+type HostServer struct {
+	Impl   *Host
+	Broker *plugin.MuxBroker
+}
+
+func (c *HostServer) HelloHost(hello string, resp *error) error {
+	*resp = c.Impl.HelloHost(hello)
+	return *resp
+}

--- a/examples/rpc/pkg/client/hostServer.go
+++ b/examples/rpc/pkg/client/hostServer.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+	plugin "github.com/sampaioletti/go-plugin/examples/go-plugin"
 )
 
 type HostServer struct {

--- a/examples/rpc/pkg/server/extServer.go
+++ b/examples/rpc/pkg/server/extServer.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+)
+
+type ExtServer struct {
+	Impl   *Extension
+	Broker *plugin.MuxBroker
+}
+
+func (s *ExtServer) HelloExtension(hello string, resp *error) error {
+	*resp = s.Impl.HelloExtension(hello)
+	return *resp
+}

--- a/examples/rpc/pkg/server/extServer.go
+++ b/examples/rpc/pkg/server/extServer.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+	plugin "github.com/sampaioletti/go-plugin/examples/go-plugin"
 )
 
 type ExtServer struct {

--- a/examples/rpc/pkg/server/extension.go
+++ b/examples/rpc/pkg/server/extension.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	hclog "github.com/hashicorp/go-hclog"
+	"gitlab.com/indis/libs/extension/api"
+)
+
+var _ api.Extender = (*Extension)(nil)
+
+type Extension struct {
+}
+
+func (p *Extension) HelloExtension(hello string) error {
+	hclog.L().Info(hello)
+	return nil
+}

--- a/examples/rpc/pkg/server/extension.go
+++ b/examples/rpc/pkg/server/extension.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	hclog "github.com/hashicorp/go-hclog"
-	"gitlab.com/indis/libs/extension/api"
+	"github.com/sampaioletti/go-plugin/examples/api"
 )
 
 var _ api.Extender = (*Extension)(nil)

--- a/examples/rpc/pkg/server/hostClient.go
+++ b/examples/rpc/pkg/server/hostClient.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"gitlab.com/indis/libs/extension/api"
+	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+)
+
+var _ api.Host = (*HostClient)(nil)
+
+type HostClient struct {
+	broker *plugin.MuxBroker
+	client *plugin.RPCConnection
+}
+
+func (h *HostClient) HelloHost(name string) error {
+	var rErr error
+	lErr := h.client.Call("Plugin.HelloHost", name, &rErr)
+	if lErr != nil {
+		return lErr
+	}
+	if rErr != nil {
+		return rErr
+	}
+	return nil
+}

--- a/examples/rpc/pkg/server/hostClient.go
+++ b/examples/rpc/pkg/server/hostClient.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"gitlab.com/indis/libs/extension/api"
-	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+	"github.com/sampaioletti/go-plugin/examples/api"
+	plugin "github.com/sampaioletti/go-plugin/examples/go-plugin"
 )
 
 var _ api.Host = (*HostClient)(nil)

--- a/examples/rpc/pkg/server/server.go
+++ b/examples/rpc/pkg/server/server.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"gitlab.com/indis/libs/extension/api"
-	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+	"github.com/sampaioletti/go-plugin/examples/api"
+	plugin "github.com/sampaioletti/go-plugin/examples/go-plugin"
 )
 
 func NewRPCServer(impl *Extension) (*RPC, error) {

--- a/examples/rpc/pkg/server/server.go
+++ b/examples/rpc/pkg/server/server.go
@@ -5,16 +5,11 @@ import (
 	plugin "gitlab.com/indis/libs/third_party/go-plugin"
 )
 
-//var _ api.Plugable = (*PluginRPCServer)(nil)
-
-// func Serve(impl api.Extender) {
-
-// }
 func NewRPCServer(impl *Extension) (*RPC, error) {
 	return &RPC{Impl: impl}, nil
 }
 
-type RPC struct { //server.RPC
+type RPC struct {
 	Impl *Extension
 }
 

--- a/examples/rpc/pkg/server/server.go
+++ b/examples/rpc/pkg/server/server.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"gitlab.com/indis/libs/extension/api"
+	plugin "gitlab.com/indis/libs/third_party/go-plugin"
+)
+
+//var _ api.Plugable = (*PluginRPCServer)(nil)
+
+// func Serve(impl api.Extender) {
+
+// }
+func NewRPCServer(impl *Extension) (*RPC, error) {
+	return &RPC{Impl: impl}, nil
+}
+
+type RPC struct { //server.RPC
+	Impl *Extension
+}
+
+func (s *RPC) Server(b *plugin.MuxBroker) (interface{}, error) {
+	return &ExtServer{s.Impl, b}, nil
+}
+func (c *RPC) Client(b *plugin.MuxBroker, client *plugin.RPCConnection) (interface{}, error) {
+	return &HostClient{b, client}, nil
+	return nil, nil
+}
+
+func (s *RPC) Serve() {
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: api.Handshake,
+		Plugins:         map[string]plugin.Plugin{"plugin": s},
+	})
+}

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -104,4 +105,9 @@ func (c *GRPCClient) Ping() error {
 	})
 
 	return err
+}
+
+// Reconnect Not Implemented for GRPC
+func (c *GRPCClient) Reconnect(client *Client) error {
+	return errors.New("Not Implemented")
 }

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -48,20 +48,20 @@ func dialGRPCConn(tls *tls.Config, dialer func(string, time.Duration) (net.Conn,
 // newGRPCClient creates a new GRPCClient. The Client argument is expected
 // to be successfully started already with a lock held.
 func newGRPCClient(doneCtx context.Context, c *Client) (*GRPCClient, error) {
-	conn, err := dialGRPCConn(c.config.TLSConfig, c.dialer)
+	conn, err := dialGRPCConn(c.Config.TLSConfig, c.dialer)
 	if err != nil {
 		return nil, err
 	}
 
 	// Start the broker.
 	brokerGRPCClient := newGRPCBrokerClient(conn)
-	broker := newGRPCBroker(brokerGRPCClient, c.config.TLSConfig)
+	broker := newGRPCBroker(brokerGRPCClient, c.Config.TLSConfig)
 	go broker.Run()
 	go brokerGRPCClient.StartStream()
 
 	return &GRPCClient{
 		Conn:    conn,
-		Plugins: c.config.Plugins,
+		Plugins: c.Config.Plugins,
 		doneCtx: doneCtx,
 		broker:  broker,
 	}, nil

--- a/plugin.go
+++ b/plugin.go
@@ -25,7 +25,7 @@ type Plugin interface {
 
 	// Client returns an interface implementation for the plugin you're
 	// serving that communicates to the server end of the plugin.
-	Client(*MuxBroker, *rpc.Client) (interface{}, error)
+	Client(*MuxBroker, *RPCConnection) (interface{}, error)
 }
 
 // GRPCPlugin is the interface that is implemented to serve/connect to

--- a/protocol.go
+++ b/protocol.go
@@ -42,4 +42,7 @@ type ClientProtocol interface {
 
 	// Ping checks that the client connection is still healthy.
 	Ping() error
+
+	// Reconnect attempts to recreate the connection to a new server
+	Reconnect(*Client) error
 }

--- a/protocol.go
+++ b/protocol.go
@@ -46,3 +46,14 @@ type ClientProtocol interface {
 	// Reconnect attempts to recreate the connection to a new server
 	Reconnect(*Client) error
 }
+
+// ClientServer...
+type ClientServer interface {
+	Serve(io.ReadWriteCloser)
+}
+
+// ServerClient [sp]Should this be io.Closer and implement reconnect
+type ServerClient interface {
+	// Dispense dispenses a new instance of the plugin with the given name.
+	Dispense(string) (interface{}, error)
+}

--- a/rpc_connection.go
+++ b/rpc_connection.go
@@ -1,0 +1,32 @@
+package plugin
+
+import (
+	"errors"
+	"net/rpc"
+	"sync"
+)
+
+// RPCConnetion acts as a werapper for a rpc.Client allowing it to be replaced safely
+type RPCConnection struct {
+	Name string
+	lock sync.RWMutex //only lock when changing rpc
+	rpc  *rpc.Client
+}
+
+// Call does a read lock and then calls the underlaying rpc Call method
+func (c *RPCConnection) Call(serviceMethod string, args interface{}, resp interface{}) error {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.rpc.Call(serviceMethod, args, resp)
+}
+
+// setRPC will replace the currently active rpc instance when it can perform a write lock
+func (c *RPCConnection) setRPC(rpc *rpc.Client) error {
+	if rpc == nil {
+		return errors.New("Nil RPC Client Provided")
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.rpc = rpc
+	return nil
+}

--- a/testing.go
+++ b/testing.go
@@ -74,12 +74,12 @@ func TestRPCConn(t testing.T) (*rpc.Client, *rpc.Server) {
 
 // TestPluginRPCConn returns a plugin RPC client and server that are connected
 // together and configured.
-func TestPluginRPCConn(t testing.T, ps map[string]Plugin, opts *TestOptions) (*RPCClient, *RPCServer) {
+func TestPluginRPCConn(t testing.T, c *ClientConfig, opts *TestOptions) (*RPCClient, *RPCServer) {
 	// Create two net.Conns we can use to shuttle our control connection
 	clientConn, serverConn := TestConn(t)
 
 	// Start up the server
-	server := &RPCServer{Plugins: ps, Stdout: new(bytes.Buffer), Stderr: new(bytes.Buffer)}
+	server := &RPCServer{Plugins: c.Plugins, Stdout: new(bytes.Buffer), Stderr: new(bytes.Buffer)}
 	if opts != nil {
 		if opts.ServerStdout != nil {
 			server.Stdout = opts.ServerStdout
@@ -91,7 +91,7 @@ func TestPluginRPCConn(t testing.T, ps map[string]Plugin, opts *TestOptions) (*R
 	go server.ServeConn(serverConn)
 
 	// Connect the client to the server
-	client, err := NewRPCClient(clientConn, ps)
+	client, err := NewRPCClient(clientConn, c)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
This is a real early pull request. Really just looking for some feedback/sanity check, and share my experience testing the library for a project.

Features
- Automatically reconnect, currently pretty dumb, but works and by using the new type RPCConnection wrapper with a mutex it is able to not have to do anything to conusmers, they just get errors until it starts working again.
- Added methods to simplify bi-directional communication. After 'normal' client/server is established uses the existing control channel and mux to use the inverse Plugin method i.e. client(host) adds a interface to its Plugin.Server(..) interface that serves the impl it wants to share. And server(plugin/extension) adds a interface to its Plugin.Client(..) method to allow it to dispense/connect to the hosts new Server
- Added example examples/rpc that demonstrates the above  

Currently has some issues:
- Exported some fields to get the functionality working, should be refactored to use interfaces (likely)
- Some code was copy/pasted from other methods to limit footprint that could be factored out into utility methods
- Need to come up with a way to know when connected, currently using timer to wait for connection (server)
- Reconnect Logic tried to use existing functions for instantiation so it is hacky
- Misc formatting/comment errors to be PR ready (if ever)

Thanks, appreciate this project. Just wanted to give back. 