### PR TITLE
protocol version negotiation

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,20 +70,23 @@ var (
 //
 // See NewClient and ClientConfig for using a Client.
 type Client struct {
-	config      *ClientConfig
-	exited      bool
-	doneLogging chan struct{}
-	l           sync.Mutex
-	address     net.Addr
-	process     *os.Process
-	client      ClientProtocol
-	protocol    Protocol
-	logger      hclog.Logger
-	doneCtx     context.Context
+	config            *ClientConfig
+	exited            bool
+	doneLogging       chan struct{}
+	l                 sync.Mutex
+	address           net.Addr
+	process           *os.Process
+	client            ClientProtocol
+	protocol          Protocol
+	logger            hclog.Logger
+	doneCtx           context.Context
+	negotiatedVersion int
+}
 
-	// NegotiatedVersion is a record of the protocol version that was returned
-	// by the server.
-	NegotiatedVersion int
+// NegotiatedVersion returns the protocol version negotiated with the server.
+// This is only valid after Start() is called.
+func (c *Client) NegotiatedVersion() int {
+	return c.negotiatedVersion
 }
 
 // ClientConfig is the configuration used to initialize a new
@@ -717,7 +720,7 @@ func (c *Client) checkProtoVersion(protoVersion string) error {
 		// doesn't need to be passed through to the ClientProtocol
 		// implementation.
 		c.config.Plugins = c.config.VersionedPlugins[version]
-		c.NegotiatedVersion = version
+		c.negotiatedVersion = version
 		c.logger.Debug("using plugin", "version", version)
 		return nil
 	}

--- a/client.go
+++ b/client.go
@@ -80,6 +80,10 @@ type Client struct {
 	protocol    Protocol
 	logger      hclog.Logger
 	doneCtx     context.Context
+
+	// NegotiatedVersion is a record of the protocol version that was returned
+	// by the server.
+	NegotiatedVersion int
 }
 
 // ClientConfig is the configuration used to initialize a new
@@ -713,6 +717,7 @@ func (c *Client) checkProtoVersion(protoVersion string) error {
 		// doesn't need to be passed through to the ClientProtocol
 		// implementation.
 		c.config.Plugins = c.config.VersionedPlugins[version]
+		c.NegotiatedVersion = version
 		c.logger.Debug("using plugin", "version", version)
 		return nil
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -19,7 +19,11 @@ import (
 
 func TestClient(t *testing.T) {
 	process := helperProcess("mock")
-	c := NewClient(&ClientConfig{Cmd: process, HandshakeConfig: testHandshake})
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+	})
 	defer c.Kill()
 
 	// Test that it parses the proper address
@@ -508,6 +512,7 @@ func TestClientStart_badVersion(t *testing.T) {
 		Cmd:             helperProcess("bad-version"),
 		StartTimeout:    50 * time.Millisecond,
 		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
 	}
 
 	c := NewClient(config)
@@ -525,6 +530,7 @@ func TestClientStart_badNegotiatedVersion(t *testing.T) {
 		StartTimeout: 50 * time.Millisecond,
 		// test-versioned-plugins only has version 2
 		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
 	}
 
 	c := NewClient(config)
@@ -542,6 +548,7 @@ func TestClient_Start_Timeout(t *testing.T) {
 		Cmd:             helperProcess("start-timeout"),
 		StartTimeout:    50 * time.Millisecond,
 		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
 	}
 
 	c := NewClient(config)
@@ -560,6 +567,7 @@ func TestClient_Stderr(t *testing.T) {
 		Cmd:             process,
 		Stderr:          stderr,
 		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
 	})
 	defer c.Kill()
 
@@ -587,6 +595,7 @@ func TestClient_StderrJSON(t *testing.T) {
 		Cmd:             process,
 		Stderr:          stderr,
 		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
 	})
 	defer c.Kill()
 
@@ -633,7 +642,11 @@ func TestClient_Stdin(t *testing.T) {
 	os.Stdin = tf
 
 	process := helperProcess("stdin")
-	c := NewClient(&ClientConfig{Cmd: process, HandshakeConfig: testHandshake})
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+	})
 	defer c.Kill()
 
 	_, err = c.Start()

--- a/client_test.go
+++ b/client_test.go
@@ -919,8 +919,8 @@ func TestClient_legacyClient(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if c.NegotiatedVersion != 1 {
-		t.Fatal("using incorrect version", c.NegotiatedVersion)
+	if c.NegotiatedVersion() != 1 {
+		t.Fatal("using incorrect version", c.NegotiatedVersion())
 	}
 
 	// Ping, should work
@@ -949,8 +949,8 @@ func TestClient_legacyServer(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if c.NegotiatedVersion != 2 {
-		t.Fatal("using incorrect version", c.NegotiatedVersion)
+	if c.NegotiatedVersion() != 2 {
+		t.Fatal("using incorrect version", c.NegotiatedVersion())
 	}
 
 	// Ping, should work
@@ -985,8 +985,8 @@ func TestClient_versionedClient(t *testing.T) {
 		t.Fatalf("err should be nil, got %s", err)
 	}
 
-	if c.NegotiatedVersion != 2 {
-		t.Fatal("using incorrect version", c.NegotiatedVersion)
+	if c.NegotiatedVersion() != 2 {
+		t.Fatal("using incorrect version", c.NegotiatedVersion())
 	}
 
 	// Grab the impl

--- a/client_test.go
+++ b/client_test.go
@@ -906,6 +906,10 @@ func TestClient_legacyClient(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	if c.NegotiatedVersion != 1 {
+		t.Fatal("using incorrect version", c.NegotiatedVersion)
+	}
+
 	// Ping, should work
 	if err := client.Ping(); err == nil {
 		t.Fatal("expected error, should negotiate wrong plugin")
@@ -930,6 +934,10 @@ func TestClient_legacyServer(t *testing.T) {
 	client, err := c.Client()
 	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+
+	if c.NegotiatedVersion != 2 {
+		t.Fatal("using incorrect version", c.NegotiatedVersion)
 	}
 
 	// Ping, should work
@@ -962,6 +970,10 @@ func TestClient_versionedClient(t *testing.T) {
 	client, err := c.Client()
 	if err != nil {
 		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	if c.NegotiatedVersion != 2 {
+		t.Fatal("using incorrect version", c.NegotiatedVersion)
 	}
 
 	// Grab the impl

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"bytes"
 	"crypto/sha256"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -178,7 +179,7 @@ func TestClient_grpc_servercrash(t *testing.T) {
 	c := NewClient(&ClientConfig{
 		Cmd:              process,
 		HandshakeConfig:  testHandshake,
-		Plugins:          testPluginMap,
+		Plugins:          testGRPCPluginMap,
 		AllowedProtocols: []Protocol{ProtocolGRPC},
 	})
 	defer c.Kill()
@@ -222,7 +223,7 @@ func TestClient_grpc(t *testing.T) {
 	c := NewClient(&ClientConfig{
 		Cmd:              process,
 		HandshakeConfig:  testHandshake,
-		Plugins:          testPluginMap,
+		Plugins:          testGRPCPluginMap,
 		AllowedProtocols: []Protocol{ProtocolGRPC},
 	})
 	defer c.Kill()
@@ -413,7 +414,7 @@ func TestClient_reattachGRPC(t *testing.T) {
 	c := NewClient(&ClientConfig{
 		Cmd:              process,
 		HandshakeConfig:  testHandshake,
-		Plugins:          testPluginMap,
+		Plugins:          testGRPCPluginMap,
 		AllowedProtocols: []Protocol{ProtocolGRPC},
 	})
 	defer c.Kill()
@@ -431,7 +432,7 @@ func TestClient_reattachGRPC(t *testing.T) {
 	c = NewClient(&ClientConfig{
 		Reattach:         reattach,
 		HandshakeConfig:  testHandshake,
-		Plugins:          testPluginMap,
+		Plugins:          testGRPCPluginMap,
 		AllowedProtocols: []Protocol{ProtocolGRPC},
 	})
 
@@ -516,6 +517,24 @@ func TestClientStart_badVersion(t *testing.T) {
 	if err == nil {
 		t.Fatal("err should not be nil")
 	}
+}
+
+func TestClientStart_badNegotiatedVersion(t *testing.T) {
+	config := &ClientConfig{
+		Cmd:          helperProcess("test-versioned-plugins"),
+		StartTimeout: 50 * time.Millisecond,
+		// test-versioned-plugins only has version 2
+		HandshakeConfig: testHandshake,
+	}
+
+	c := NewClient(config)
+	defer c.Kill()
+
+	_, err := c.Start()
+	if err == nil {
+		t.Fatal("err should not be nil")
+	}
+	fmt.Println(err)
 }
 
 func TestClient_Start_Timeout(t *testing.T) {
@@ -773,7 +792,7 @@ func TestClient_TLS_grpc(t *testing.T) {
 	c := NewClient(&ClientConfig{
 		Cmd:              process,
 		HandshakeConfig:  testHandshake,
-		Plugins:          testPluginMap,
+		Plugins:          testGRPCPluginMap,
 		TLSConfig:        tlsConfig,
 		AllowedProtocols: []Protocol{ProtocolGRPC},
 	})
@@ -852,6 +871,119 @@ func TestClient_ping(t *testing.T) {
 	}
 }
 
+func TestClient_wrongVersion(t *testing.T) {
+	process := helperProcess("test-proto-upgraded-plugin")
+	c := NewClient(&ClientConfig{
+		Cmd:              process,
+		HandshakeConfig:  testHandshake,
+		Plugins:          testGRPCPluginMap,
+		AllowedProtocols: []Protocol{ProtocolGRPC},
+	})
+	defer c.Kill()
+
+	// Get the client
+	_, err := c.Client()
+	if err == nil {
+		t.Fatal("expected incorrect protocol version server")
+	}
+
+}
+
+func TestClient_legacyClient(t *testing.T) {
+	process := helperProcess("test-proto-upgraded-plugin")
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testVersionedHandshake,
+		VersionedPlugins: map[int]PluginSet{
+			1: testPluginMap,
+		},
+	})
+	defer c.Kill()
+
+	// Get the client
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Ping, should work
+	if err := client.Ping(); err == nil {
+		t.Fatal("expected error, should negotiate wrong plugin")
+	}
+}
+
+func TestClient_legacyServer(t *testing.T) {
+	// test using versioned plugins version when the server supports only
+	// supports one
+	process := helperProcess("test-proto-upgraded-client")
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testVersionedHandshake,
+		VersionedPlugins: map[int]PluginSet{
+			2: testGRPCPluginMap,
+		},
+		AllowedProtocols: []Protocol{ProtocolGRPC},
+	})
+	defer c.Kill()
+
+	// Get the client
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Ping, should work
+	if err := client.Ping(); err == nil {
+		t.Fatal("expected error, should negotiate wrong plugin")
+	}
+}
+
+func TestClient_versionedClient(t *testing.T) {
+	process := helperProcess("test-versioned-plugins")
+	c := NewClient(&ClientConfig{
+		Cmd:             process,
+		HandshakeConfig: testVersionedHandshake,
+		VersionedPlugins: map[int]PluginSet{
+			2: testGRPCPluginMap,
+		},
+		AllowedProtocols: []Protocol{ProtocolGRPC},
+	})
+	defer c.Kill()
+
+	if _, err := c.Start(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if v := c.Protocol(); v != ProtocolGRPC {
+		t.Fatalf("bad: %s", v)
+	}
+
+	// Grab the RPC client
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	// Grab the impl
+	raw, err := client.Dispense("test")
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	_, ok := raw.(testInterface)
+	if !ok {
+		t.Fatalf("bad: %#v", raw)
+	}
+
+	c.process.Kill()
+
+	select {
+	case <-c.doneCtx.Done():
+	case <-time.After(time.Second * 2):
+		t.Fatal("Context was not closed")
+	}
+}
+
 func TestClient_logger(t *testing.T) {
 	t.Run("net/rpc", func(t *testing.T) { testClient_logger(t, "netrpc") })
 	t.Run("grpc", func(t *testing.T) { testClient_logger(t, "grpc") })
@@ -873,7 +1005,7 @@ func testClient_logger(t *testing.T, proto string) {
 	c := NewClient(&ClientConfig{
 		Cmd:              process,
 		HandshakeConfig:  testHandshake,
-		Plugins:          testPluginMap,
+		Plugins:          testGRPCPluginMap,
 		Logger:           clientLogger,
 		AllowedProtocols: []Protocol{ProtocolNetRPC, ProtocolGRPC},
 	})

--- a/examples/grpc/plugin-go-grpc/main.go
+++ b/examples/grpc/plugin-go-grpc/main.go
@@ -25,7 +25,7 @@ func main() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: shared.Handshake,
 		Plugins: map[string]plugin.Plugin{
-			"kv": &shared.KVPlugin{Impl: &KV{}},
+			"kv": &shared.KVGRPCPlugin{Impl: &KV{}},
 		},
 
 		// A non-nil value here enables gRPC serving for this plugin...

--- a/examples/grpc/shared/interface.go
+++ b/examples/grpc/shared/interface.go
@@ -13,6 +13,7 @@ import (
 
 // Handshake is a common handshake that is shared by plugin and host.
 var Handshake = plugin.HandshakeConfig{
+	// This isn't required when using VersionedPlugins
 	ProtocolVersion:  1,
 	MagicCookieKey:   "BASIC_PLUGIN",
 	MagicCookieValue: "hello",
@@ -30,8 +31,6 @@ type KV interface {
 }
 
 // This is the implementation of plugin.Plugin so we can serve/consume this.
-// We also implement GRPCPlugin so that this plugin can be served over
-// gRPC.
 type KVPlugin struct {
 	// Concrete implementation, written in Go. This is only used for plugins
 	// that are written in Go.
@@ -46,11 +45,20 @@ func (*KVPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error)
 	return &RPCClient{client: c}, nil
 }
 
-func (p *KVPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error {
+// This is the implementation of plugin.GRPCPlugin so we can serve/consume this.
+type KVGRPCPlugin struct {
+	// GRPCPlugin must still implement the Plugin interface
+	plugin.Plugin
+	// Concrete implementation, written in Go. This is only used for plugins
+	// that are written in Go.
+	Impl KV
+}
+
+func (p *KVGRPCPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error {
 	proto.RegisterKVServer(s, &GRPCServer{Impl: p.Impl})
 	return nil
 }
 
-func (p *KVPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (p *KVGRPCPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
 	return &GRPCClient{client: proto.NewKVClient(c)}, nil
 }

--- a/examples/negotiated/.gitignore
+++ b/examples/negotiated/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+kv
+kv-*
+kv_*
+!kv_*.py

--- a/examples/negotiated/README.md
+++ b/examples/negotiated/README.md
@@ -1,0 +1,30 @@
+# Negotiated version KV Example
+
+This example builds a simple key/value store CLI where the plugin version can
+be negotiated between client and server.
+
+```sh
+# This builds the main CLI
+$ go build -o kv
+
+# This builds the plugin written in Go
+$ go build -o kv-plugin ./plugin-go
+
+# Write a value using proto version 3 and grpc
+$ KV_PROTO=grpc ./kv put hello world
+
+# Read it back using proto version 2 and netrpc
+$ KV_PROTO=netrpc ./kv get hello
+world
+
+Written from plugin version 3
+Read by plugin version 2
+```
+
+# Negotiated Protocol
+
+The Client sends the list of available plugin versions to the server. When
+presented with a list of plugin versions, the server iterates over them in
+reverse, and uses the highest numbered match to choose the plugins to execute.
+If a legacy client is used and no versions are sent to the server, the server
+will default to the oldest version in its configuration.

--- a/examples/negotiated/main.go
+++ b/examples/negotiated/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-plugin/examples/grpc/shared"
+)
+
+func main() {
+	// We don't want to see the plugin logs.
+	log.SetOutput(ioutil.Discard)
+
+	plugins := map[int]plugin.PluginSet{}
+
+	// Both version can be supported, but switch the implementation to
+	// demonstrate version negoation.
+	switch os.Getenv("KV_PROTO") {
+	case "netrpc":
+		plugins[2] = plugin.PluginSet{
+			"kv": &shared.KVPlugin{},
+		}
+	case "grpc":
+		plugins[3] = plugin.PluginSet{
+			"kv": &shared.KVGRPCPlugin{},
+		}
+	default:
+		fmt.Println("must set KV_PROTO to netrpc or grpc")
+		os.Exit(1)
+	}
+
+	// We're a host. Start by launching the plugin process.
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig:  shared.Handshake,
+		VersionedPlugins: plugins,
+		Cmd:              exec.Command("./kv-plugin"),
+		AllowedProtocols: []plugin.Protocol{
+			plugin.ProtocolNetRPC, plugin.ProtocolGRPC},
+	})
+	defer client.Kill()
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		fmt.Println("Error:", err.Error())
+		os.Exit(1)
+	}
+
+	// Request the plugin
+	raw, err := rpcClient.Dispense("kv")
+	if err != nil {
+		fmt.Println("Error:", err.Error())
+		os.Exit(1)
+	}
+
+	// We should have a KV store now! This feels like a normal interface
+	// implementation but is in fact over an RPC connection.
+	kv := raw.(shared.KV)
+	os.Args = os.Args[1:]
+	switch os.Args[0] {
+	case "get":
+		result, err := kv.Get(os.Args[1])
+		if err != nil {
+			fmt.Println("Error:", err.Error())
+			os.Exit(1)
+		}
+
+		fmt.Println(string(result))
+
+	case "put":
+		err := kv.Put(os.Args[1], []byte(os.Args[2]))
+		if err != nil {
+			fmt.Println("Error:", err.Error())
+			os.Exit(1)
+		}
+
+	default:
+		fmt.Println("Please only use 'get' or 'put'")
+		os.Exit(1)
+	}
+}

--- a/examples/negotiated/plugin-go/main.go
+++ b/examples/negotiated/plugin-go/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-plugin/examples/grpc/shared"
+)
+
+// Here is a real implementation of KV that uses grpc and  writes to a local
+// file with the key name and the contents are the value of the key.
+type KVGRPC struct{}
+
+func (KVGRPC) Put(key string, value []byte) error {
+	value = []byte(fmt.Sprintf("%s\n\nWritten from plugin version 3\n", string(value)))
+	return ioutil.WriteFile("kv_"+key, value, 0644)
+}
+
+func (KVGRPC) Get(key string) ([]byte, error) {
+	d, err := ioutil.ReadFile("kv_" + key)
+	if err != nil {
+		return nil, err
+	}
+	return append(d, []byte("Read by plugin version 3\n")...), nil
+}
+
+// Here is a real implementation of KV that writes to a local file with
+// the key name and the contents are the value of the key.
+type KV struct{}
+
+func (KV) Put(key string, value []byte) error {
+	value = []byte(fmt.Sprintf("%s\n\nWritten from plugin version 2\n", string(value)))
+	return ioutil.WriteFile("kv_"+key, value, 0644)
+}
+
+func (KV) Get(key string) ([]byte, error) {
+	d, err := ioutil.ReadFile("kv_" + key)
+	if err != nil {
+		return nil, err
+	}
+	return append(d, []byte("Read by plugin version 2\n")...), nil
+}
+
+func main() {
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: shared.Handshake,
+		VersionedPlugins: map[int]plugin.PluginSet{
+			// Version 2 only uses NetRPC
+			2: {
+				"kv": &shared.KVPlugin{Impl: &KV{}},
+			},
+			// Version 3 only uses GRPC
+			3: {
+				"kv": &shared.KVGRPCPlugin{Impl: &KVGRPC{}},
+			},
+		},
+
+		// A non-nil value here enables gRPC serving for this plugin...
+		GRPCServer: plugin.DefaultGRPCServer,
+	})
+}

--- a/grpc_client_test.go
+++ b/grpc_client_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestGRPCClient_App(t *testing.T) {
 	client, server := TestPluginGRPCConn(t, map[string]Plugin{
-		"test": new(testInterfacePlugin),
+		"test": new(testGRPCInterfacePlugin),
 	})
 	defer client.Close()
 	defer server.Stop()
@@ -55,7 +55,7 @@ func TestGRPCConn_BidirectionalPing(t *testing.T) {
 
 func TestGRPCC_Stream(t *testing.T) {
 	client, server := TestPluginGRPCConn(t, map[string]Plugin{
-		"test": new(testInterfacePlugin),
+		"test": new(testGRPCInterfacePlugin),
 	})
 	defer client.Close()
 	defer server.Stop()
@@ -83,7 +83,7 @@ func TestGRPCC_Stream(t *testing.T) {
 
 func TestGRPCClient_Ping(t *testing.T) {
 	client, server := TestPluginGRPCConn(t, map[string]Plugin{
-		"test": new(testInterfacePlugin),
+		"test": new(testGRPCInterfacePlugin),
 	})
 	defer client.Close()
 	defer server.Stop()

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -23,9 +23,13 @@ import (
 // Test that NetRPCUnsupportedPlugin implements the correct interfaces.
 var _ Plugin = new(NetRPCUnsupportedPlugin)
 
-// testAPIVersion is the ProtocolVersion we use for testing.
 var testHandshake = HandshakeConfig{
 	ProtocolVersion:  1,
+	MagicCookieKey:   "TEST_MAGIC_COOKIE",
+	MagicCookieValue: "test",
+}
+
+var testVersionedHandshake = HandshakeConfig{
 	MagicCookieKey:   "TEST_MAGIC_COOKIE",
 	MagicCookieValue: "test",
 }
@@ -56,16 +60,43 @@ func (p *testInterfacePlugin) Client(b *MuxBroker, c *rpc.Client) (interface{}, 
 	return &testInterfaceClient{Client: c}, nil
 }
 
-func (p *testInterfacePlugin) GRPCServer(b *GRPCBroker, s *grpc.Server) error {
+func (p *testInterfacePlugin) impl() testInterface {
+	if p.Impl != nil {
+		return p.Impl
+	}
+
+	return &testInterfaceImpl{
+		logger: hclog.New(&hclog.LoggerOptions{
+			Level:      hclog.Trace,
+			Output:     os.Stderr,
+			JSONFormat: true,
+		}),
+	}
+}
+
+// testGRPCInterfacePlugin is a test implementation of the GRPCPlugin interface
+type testGRPCInterfacePlugin struct {
+	Impl testInterface
+}
+
+func (p *testGRPCInterfacePlugin) Server(b *MuxBroker) (interface{}, error) {
+	return &testInterfaceServer{Impl: p.impl()}, nil
+}
+
+func (p *testGRPCInterfacePlugin) Client(b *MuxBroker, c *rpc.Client) (interface{}, error) {
+	return &testInterfaceClient{Client: c}, nil
+}
+
+func (p *testGRPCInterfacePlugin) GRPCServer(b *GRPCBroker, s *grpc.Server) error {
 	grpctest.RegisterTestServer(s, &testGRPCServer{broker: b, Impl: p.impl()})
 	return nil
 }
 
-func (p *testInterfacePlugin) GRPCClient(doneCtx context.Context, b *GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (p *testGRPCInterfacePlugin) GRPCClient(doneCtx context.Context, b *GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
 	return &testGRPCClient{broker: b, Client: grpctest.NewTestClient(c)}, nil
 }
 
-func (p *testInterfacePlugin) impl() testInterface {
+func (p *testGRPCInterfacePlugin) impl() testInterface {
 	if p.Impl != nil {
 		return p.Impl
 	}
@@ -142,6 +173,11 @@ func (s *testInterfaceServer) PrintKV(args map[string]interface{}, _ *struct{}) 
 // testPluginMap can be used for tests as a plugin map
 var testPluginMap = map[string]Plugin{
 	"test": new(testInterfacePlugin),
+}
+
+// testGRPCPluginMap can be used for tests as that need a GRPC plugin
+var testGRPCPluginMap = map[string]Plugin{
+	"test": new(testGRPCInterfacePlugin),
 }
 
 // testGRPCServer is the implementation of our GRPC service.
@@ -337,8 +373,6 @@ func helperProcess(s ...string) *exec.Cmd {
 	cs = append(cs, s...)
 	env := []string{
 		"GO_WANT_HELPER_PROCESS=1",
-		"PLUGIN_MIN_PORT=10000",
-		"PLUGIN_MAX_PORT=25000",
 	}
 
 	cmd := exec.Command(os.Args[0], cs...)
@@ -384,6 +418,10 @@ func TestHelperProcess(*testing.T) {
 
 	testPluginMap := map[string]Plugin{
 		"test": &testInterfacePlugin{Impl: testPlugin},
+	}
+
+	testGRPCPluginMap := map[string]Plugin{
+		"test": &testGRPCInterfacePlugin{Impl: testPlugin},
 	}
 
 	cmd, args := args[0], args[1:]
@@ -451,7 +489,7 @@ func TestHelperProcess(*testing.T) {
 	case "test-grpc":
 		Serve(&ServeConfig{
 			HandshakeConfig: testHandshake,
-			Plugins:         testPluginMap,
+			Plugins:         testGRPCPluginMap,
 			GRPCServer:      DefaultGRPCServer,
 		})
 
@@ -461,7 +499,7 @@ func TestHelperProcess(*testing.T) {
 		// Serve!
 		Serve(&ServeConfig{
 			HandshakeConfig: testHandshake,
-			Plugins:         testPluginMap,
+			Plugins:         testGRPCPluginMap,
 			GRPCServer:      DefaultGRPCServer,
 			TLSProvider:     helperTLSProvider,
 		})
@@ -506,6 +544,50 @@ func TestHelperProcess(*testing.T) {
 			HandshakeConfig: testHandshake,
 			Plugins:         testPluginMap,
 			TLSProvider:     helperTLSProvider,
+		})
+
+		// Shouldn't reach here but make sure we exit anyways
+		os.Exit(0)
+	case "test-versioned-plugins":
+		// Serve!
+		Serve(&ServeConfig{
+			HandshakeConfig: testVersionedHandshake,
+			VersionedPlugins: map[int]PluginSet{
+				2: testGRPCPluginMap,
+			},
+			GRPCServer:  DefaultGRPCServer,
+			TLSProvider: helperTLSProvider,
+		})
+
+		// Shouldn't reach here but make sure we exit anyways
+		os.Exit(0)
+	case "test-proto-upgraded-plugin":
+		// Serve 2 plugins over different protocols
+		Serve(&ServeConfig{
+			HandshakeConfig: testVersionedHandshake,
+			VersionedPlugins: map[int]PluginSet{
+				1: PluginSet{
+					"old": &testInterfacePlugin{Impl: testPlugin},
+				},
+				2: testGRPCPluginMap,
+			},
+			GRPCServer:  DefaultGRPCServer,
+			TLSProvider: helperTLSProvider,
+		})
+
+		// Shouldn't reach here but make sure we exit anyways
+		os.Exit(0)
+	case "test-proto-upgraded-client":
+		// Serve 2 plugins over different protocols
+		Serve(&ServeConfig{
+			HandshakeConfig: HandshakeConfig{
+				ProtocolVersion:  2,
+				MagicCookieKey:   "TEST_MAGIC_COOKIE",
+				MagicCookieValue: "test",
+			},
+			Plugins:     testGRPCPluginMap,
+			GRPCServer:  DefaultGRPCServer,
+			TLSProvider: helperTLSProvider,
 		})
 
 		// Shouldn't reach here but make sure we exit anyways

--- a/server.go
+++ b/server.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"sort"
 	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"github.com/hashicorp/go-hclog"
@@ -36,6 +38,8 @@ type HandshakeConfig struct {
 	// ProtocolVersion is the version that clients must match on to
 	// agree they can communicate. This should match the ProtocolVersion
 	// set on ClientConfig when using a plugin.
+	// This field is not required if VersionedPlugins are being used in the
+	// Client or Server configurations.
 	ProtocolVersion uint
 
 	// MagicCookieKey and value are used as a very basic verification
@@ -46,6 +50,10 @@ type HandshakeConfig struct {
 	MagicCookieValue string
 }
 
+// PluginSet is a set of plugins provided to be registered in the plugin
+// server.
+type PluginSet map[string]Plugin
+
 // ServeConfig configures what sorts of plugins are served.
 type ServeConfig struct {
 	// HandshakeConfig is the configuration that must match clients.
@@ -55,7 +63,13 @@ type ServeConfig struct {
 	TLSProvider func() (*tls.Config, error)
 
 	// Plugins are the plugins that are served.
-	Plugins map[string]Plugin
+	// The implied version of this PluginSet is the Handshake.ProtocolVersion.
+	Plugins PluginSet
+
+	// VersionedPlugins is a map of PluginSets for specific protocol versions.
+	// These can be used to negotiate a compatible version between client and
+	// server. If this is set, Handshake.ProtocolVersion is not required.
+	VersionedPlugins map[int]PluginSet
 
 	// GRPCServer should be non-nil to enable serving the plugins over
 	// gRPC. This is a function to create the server when needed with the
@@ -72,14 +86,74 @@ type ServeConfig struct {
 	Logger hclog.Logger
 }
 
-// Protocol returns the protocol that this server should speak.
-func (c *ServeConfig) Protocol() Protocol {
-	result := ProtocolNetRPC
-	if c.GRPCServer != nil {
-		result = ProtocolGRPC
+// protocolVersion determines the protocol version and plugin set to be used by
+// the server. In the event that there is no suitable version, the last version
+// in the config is returned leaving the client to report the incompatibility.
+func protocolVersion(opts *ServeConfig) (int, Protocol, PluginSet) {
+	protoVersion := int(opts.ProtocolVersion)
+	pluginSet := opts.Plugins
+	protoType := ProtocolNetRPC
+	// check if the client sent a list of acceptable versions
+	var clientVersions []int
+	if vs := os.Getenv("PLUGIN_PROTOCOL_VERSIONS"); vs != "" {
+		for _, s := range strings.Split(vs, ",") {
+			v, err := strconv.Atoi(s)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "server sent invalid plugin version %q", s)
+				continue
+			}
+			clientVersions = append(clientVersions, v)
+		}
 	}
 
-	return result
+	// we want to iterate in reverse order, to ensure we match the newest
+	// compatible plugin version.
+	sort.Sort(sort.Reverse(sort.IntSlice(clientVersions)))
+
+	// set the old un-versioned fields as if they were versioned plugins
+	if opts.VersionedPlugins == nil {
+		opts.VersionedPlugins = make(map[int]PluginSet)
+	}
+
+	if pluginSet != nil {
+		opts.VersionedPlugins[protoVersion] = pluginSet
+	}
+
+	// sort the version to make sure we match the latest first
+	var versions []int
+	for v := range opts.VersionedPlugins {
+		versions = append(versions, v)
+	}
+
+	sort.Sort(sort.Reverse(sort.IntSlice(versions)))
+
+	// see if we have multiple versions of Plugins to choose from
+	for _, version := range versions {
+		// record each version, since we guarantee that this returns valid
+		// values even if they are not a protocol match.
+		protoVersion = version
+		pluginSet = opts.VersionedPlugins[version]
+
+		// all plugins in a set must use the same transport, so check the first
+		// for the protocol type
+		for _, p := range pluginSet {
+			switch p.(type) {
+			case GRPCPlugin:
+				protoType = ProtocolGRPC
+			default:
+				protoType = ProtocolNetRPC
+			}
+			break
+		}
+
+		for _, clientVersion := range clientVersions {
+			if clientVersion == protoVersion {
+				return protoVersion, protoType, pluginSet
+			}
+		}
+	}
+
+	return protoVersion, protoType, pluginSet
 }
 
 // Serve serves the plugins given by ServeConfig.
@@ -106,6 +180,10 @@ func Serve(opts *ServeConfig) {
 				"load any plugins automatically\n")
 		os.Exit(1)
 	}
+
+	// negotiate the version and plugins
+	// start with default version in the handshake config
+	protoVersion, protoType, pluginSet := protocolVersion(opts)
 
 	// Logging goes to the original stderr
 	log.SetOutput(os.Stderr)
@@ -160,7 +238,7 @@ func Serve(opts *ServeConfig) {
 
 	// Build the server type
 	var server ServerProtocol
-	switch opts.Protocol() {
+	switch protoType {
 	case ProtocolNetRPC:
 		// If we have a TLS configuration then we wrap the listener
 		// ourselves and do it at that level.
@@ -170,7 +248,7 @@ func Serve(opts *ServeConfig) {
 
 		// Create the RPC server to dispense
 		server = &RPCServer{
-			Plugins: opts.Plugins,
+			Plugins: pluginSet,
 			Stdout:  stdout_r,
 			Stderr:  stderr_r,
 			DoneCh:  doneCh,
@@ -179,7 +257,7 @@ func Serve(opts *ServeConfig) {
 	case ProtocolGRPC:
 		// Create the gRPC server
 		server = &GRPCServer{
-			Plugins: opts.Plugins,
+			Plugins: pluginSet,
 			Server:  opts.GRPCServer,
 			TLS:     tlsConfig,
 			Stdout:  stdout_r,
@@ -188,7 +266,7 @@ func Serve(opts *ServeConfig) {
 		}
 
 	default:
-		panic("unknown server protocol: " + opts.Protocol())
+		panic("unknown server protocol: " + protoType)
 	}
 
 	// Initialize the servers
@@ -208,13 +286,13 @@ func Serve(opts *ServeConfig) {
 
 	logger.Debug("plugin address", "network", listener.Addr().Network(), "address", listener.Addr().String())
 
-	// Output the address and service name to stdout so that core can bring it up.
+	// Output the address and service name to stdout so that the client can bring it up.
 	fmt.Printf("%d|%d|%s|%s|%s%s\n",
 		CoreProtocolVersion,
-		opts.ProtocolVersion,
+		protoVersion,
 		listener.Addr().Network(),
 		listener.Addr().String(),
-		opts.Protocol(),
+		protoType,
 		extra)
 	os.Stdout.Sync()
 

--- a/server.go
+++ b/server.go
@@ -153,6 +153,12 @@ func protocolVersion(opts *ServeConfig) (int, Protocol, PluginSet) {
 		}
 	}
 
+	// Return the lowest version as the fallback.
+	// Since we iterated over all the versions in reverse order above, these
+	// values are from the lowest version number plugins (which may be from
+	// a combination of the Handshake.ProtocolVersion and ServeConfig.Plugins
+	// fields). This allows serving the oldest version of our plugins to a
+	// legacy client that did not send a PLUGIN_PROTOCOL_VERSIONS list.
 	return protoVersion, protoType, pluginSet
 }
 


### PR DESCRIPTION
This is an initial implementation of backwards compatible protocol version negotiation.
The development version if Terraform was implementing a similar mechanism to allow grpc plugins to be backward compatible with previous core versions, but the utility may be generally useful to other users of go-plugin.

The basic design is that rather than having a single `ProtocolVersion` defined in the handshake, the server and client config each have a mapping of protocol versions to plugin sets (`VersionedPlugins`). The client versions are communicated to the server as a comma separated list in the `PLUGIN_PROTOCOL_VERSIONS` environment variable.

The server iterates through the `PLUGIN_PROTOCOL_VERSIONS` values in descending order, and returns the first matching plugin version, along with the protocol type of `netrpc` or `grpc`.

The PR is meant to be protocol compatible with previous versions, but it is not completely code-compatible. The client and server determine protocol type by inspecting the type of the `Plugin` interface implementation, and it is possible that some implementations (like the test fixtures) implement the `GRPCPlugin` type while not using the protocol. This is a trade-off that allows us to not require an additional mapping of each versioned plugin to a protocol type, which would also need to be reflected in the handshake itself.