### PR TITLE
Client: Add more debug details to log

### DIFF
--- a/client.go
+++ b/client.go
@@ -542,6 +542,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 
 	// Set the process
 	c.process = cmd.Process
+	c.logger.Debug("plugin started", "path", cmd.Path, "pid", c.process.Pid)
 
 	// Make sure the command is properly cleaned up if there is an error
 	defer func() {
@@ -565,10 +566,19 @@ func (c *Client) Start() (addr net.Addr, err error) {
 		defer stdout_w.Close()
 
 		// Wait for the command to end.
-		cmd.Wait()
+		err := cmd.Wait()
+
+		debugMsgArgs := []interface{}{
+			"path", cmd.Path,
+			"pid", c.process.Pid,
+		}
+		if err != nil {
+			debugMsgArgs = append(debugMsgArgs,
+				[]interface{}{"error", err.Error()}...)
+		}
 
 		// Log and make sure to flush the logs write away
-		c.logger.Debug("plugin process exited", "path", cmd.Path)
+		c.logger.Debug("plugin process exited", debugMsgArgs...)
 		os.Stderr.Sync()
 
 		// Mark that we exited

--- a/examples/grpc/main.go
+++ b/examples/grpc/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	// Request the plugin
-	raw, err := rpcClient.Dispense("kv")
+	raw, err := rpcClient.Dispense("kv_grpc")
 	if err != nil {
 		fmt.Println("Error:", err.Error())
 		os.Exit(1)
@@ -61,7 +61,8 @@ func main() {
 		}
 
 	default:
-		fmt.Println("Please only use 'get' or 'put'")
+		fmt.Printf("Please only use 'get' or 'put', given: %q", os.Args[0])
 		os.Exit(1)
 	}
+	os.Exit(0)
 }

--- a/examples/grpc/shared/interface.go
+++ b/examples/grpc/shared/interface.go
@@ -21,7 +21,8 @@ var Handshake = plugin.HandshakeConfig{
 
 // PluginMap is the map of plugins we can dispense.
 var PluginMap = map[string]plugin.Plugin{
-	"kv": &KVPlugin{},
+	"kv_grpc": &KVGRPCPlugin{},
+	"kv":      &KVPlugin{},
 }
 
 // KV is the interface that we're exposing as a plugin.


### PR DESCRIPTION
Closes #78 

## Before

```
root@b05297468e24:/go/src/github.com/hashicorp/go-plugin/examples/grpc# KV_PLUGIN=./test ./main get test
2018-09-26T16:14:54.358Z [DEBUG] plugin: starting plugin: path=/bin/sh args="[sh -c ./test]"
2018-09-26T16:14:54.359Z [DEBUG] plugin: waiting for RPC address: path=/bin/sh
2018-09-26T16:15:15.909Z [DEBUG] plugin: plugin process exited: path=/bin/sh
2018-09-26T16:15:15.914Z [DEBUG] plugin.sh: Killed
Error: plugin exited before we could connect
```

## After

```
root@b05297468e24:/go/src/github.com/hashicorp/go-plugin/examples/grpc# KV_PLUGIN=./test ./main get test
2018-09-26T16:23:03.051Z [DEBUG] plugin: starting plugin: path=/bin/sh args="[sh -c ./test]"
2018-09-26T16:23:03.052Z [DEBUG] plugin: plugin started: path=/bin/sh pid=1471
2018-09-26T16:23:03.052Z [DEBUG] plugin: waiting for RPC address: path=/bin/sh
2018-09-26T16:23:23.171Z [DEBUG] plugin.sh: Killed
2018-09-26T16:23:23.173Z [DEBUG] plugin: plugin process exited: path=/bin/sh pid=1471 error="exit status 137"
Error: plugin exited before we could connect
```

----

Tested with the following simple plugin code:

```go
package main

import (
	"fmt"
	"time"
)

func main() {
	slice := []string{}
	for i := 0; i < 999999999; i++ {
		slice = append(slice, fmt.Sprintf("Lorem Ipsum dolor sit amet %d", i))
	}
	fmt.Printf("%d", len(slice))
	time.Sleep(1 * time.Second)
}
```