### PR TITLE
ignore interrupts instead of manually eating them

### DIFF
--- a/server.go
+++ b/server.go
@@ -331,8 +331,17 @@ func Serve(opts *ServeConfig) {
 		serverCert)
 	os.Stdout.Sync()
 
-	// Ignore interrupts
-	signal.Ignore(os.Interrupt)
+	// Eat the interrupts
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	go func() {
+		count := 0
+		for {
+			<-ch
+			count++
+			logger.Trace("plugin received interrupt signal, ignoring", "count", count)
+		}
+	}()
 
 	// Set our new out, err
 	os.Stdout = stdout_w

--- a/server.go
+++ b/server.go
@@ -15,10 +15,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync/atomic"
 
-	"github.com/hashicorp/go-hclog"
-
+	hclog "github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc"
 )
 
@@ -333,17 +331,8 @@ func Serve(opts *ServeConfig) {
 		serverCert)
 	os.Stdout.Sync()
 
-	// Eat the interrupts
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt)
-	go func() {
-		var count int32 = 0
-		for {
-			<-ch
-			newCount := atomic.AddInt32(&count, 1)
-			logger.Debug("plugin received interrupt signal, ignoring", "count", newCount)
-		}
-	}()
+	// Ignore interrupts
+	signal.Ignore(os.Interrupt)
 
 	// Set our new out, err
 	os.Stdout = stdout_w


### PR DESCRIPTION
While trying to decrease log noise prior to the Nomad 0.9.0 release, I noticed these log lines on agent shutdown (1 or 2 lines per task depending on driver):

```
2019-01-18T12:45:56.342-0800 [DEBUG] client.alloc_runner.task_runner.task_hook.logmon.nomad: plugin received interrupt signal, ignoring: alloc_id=51df16f9-b8dd-2a02-0976-3205f9a53c4a task=redis count=1 @module=logmon timestamp=2019-01-18T12:45:56.310-0800
```

I found their source here:

https://github.com/hashicorp/go-plugin/blob/f444068e8f5a19853177f7aa0aea7e7d95b5b528/server.go#L336-L346

~Is this log message useful to anyone? I don't believe it is to Nomad. If it is not useful I'd propose merging this PR.~ Testing advice welcome. I've only manually tested with Nomad.

*Update:* Found out it is useful during development (see below). Updated PR with this patch.

If this log message is useful I'd propose the following patch instead:

```diff
diff --git a/server.go b/server.go
index fc9f05a..59a46e8 100644
--- a/server.go
+++ b/server.go
@@ -15,10 +15,8 @@ import (
        "sort"
        "strconv"
        "strings"
-       "sync/atomic"
-
-       "github.com/hashicorp/go-hclog"

+       hclog "github.com/hashicorp/go-hclog"
        "google.golang.org/grpc"
 )

@@ -337,11 +335,11 @@ func Serve(opts *ServeConfig) {
        ch := make(chan os.Signal, 1)
        signal.Notify(ch, os.Interrupt)
        go func() {
-               var count int32 = 0
+               count := 0
                for {
                        <-ch
-                       newCount := atomic.AddInt32(&count, 1)
-                       logger.Debug("plugin received interrupt signal, ignoring", "count", newCount)
+                       count++
+                       logger.Trace("plugin received interrupt signal, ignoring", "count", count)
                }
        }()
```

This lowers the log level to Trace and removes the unneeded atomic.