### PR TITLE
Log unexpected json, and set levels for plain text logs

### DIFF
--- a/client.go
+++ b/client.go
@@ -989,6 +989,11 @@ func (c *Client) logStderr(r io.Reader) {
 				l.Warn(entry.Message, out...)
 			case hclog.Error:
 				l.Error(entry.Message, out...)
+			default:
+				// if there was no log level, it's likely this is unexpected
+				// json from something other than hclog, and we should output
+				// it verbatim.
+				l.Debug(string(line))
 			}
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -973,7 +973,22 @@ func (c *Client) logStderr(r io.Reader) {
 		entry, err := parseJSON(line)
 		// If output is not JSON format, print directly to Debug
 		if err != nil {
-			l.Debug(string(line))
+			// Attempt to infer the desired log level from the commonly used
+			// string prefixes
+			switch line := string(line); {
+			case strings.HasPrefix("[TRACE]", line):
+				l.Trace(line)
+			case strings.HasPrefix("[DEBUG]", line):
+				l.Debug(line)
+			case strings.HasPrefix("[INFO]", line):
+				l.Info(line)
+			case strings.HasPrefix("[WARN]", line):
+				l.Warn(line)
+			case strings.HasPrefix("[ERROR]", line):
+				l.Error(line)
+			default:
+				l.Debug(line)
+			}
 		} else {
 			out := flattenKVPairs(entry.KVPairs)
 

--- a/client_test.go
+++ b/client_test.go
@@ -617,10 +617,22 @@ func TestClient_Stderr(t *testing.T) {
 func TestClient_StderrJSON(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	process := helperProcess("stderr-json")
+
+	var logBuf bytes.Buffer
+	mutex := new(sync.Mutex)
+	// Custom hclog.Logger
+	testLogger := hclog.New(&hclog.LoggerOptions{
+		Name:   "test-logger",
+		Level:  hclog.Trace,
+		Output: &logBuf,
+		Mutex:  mutex,
+	})
+
 	c := NewClient(&ClientConfig{
 		Cmd:             process,
 		Stderr:          stderr,
 		HandshakeConfig: testHandshake,
+		Logger:          testLogger,
 		Plugins:         testPluginMap,
 	})
 	defer c.Kill()
@@ -637,12 +649,18 @@ func TestClient_StderrJSON(t *testing.T) {
 		t.Fatal("process failed to exit gracefully")
 	}
 
-	if !strings.Contains(stderr.String(), "[\"HELLO\"]\n") {
-		t.Fatalf("bad log data: '%s'", stderr.String())
+	logOut := logBuf.String()
+
+	if !strings.Contains(logOut, "[\"HELLO\"]\n") {
+		t.Fatalf("missing json list: '%s'", logOut)
 	}
 
-	if !strings.Contains(stderr.String(), "12345\n") {
-		t.Fatalf("bad log data: '%s'", stderr.String())
+	if !strings.Contains(logOut, "12345\n") {
+		t.Fatalf("missing line with raw number: '%s'", logOut)
+	}
+
+	if !strings.Contains(logOut, "{\"a\":1}") {
+		t.Fatalf("missing json object: '%s'", logOut)
 	}
 }
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-plugin/test/grpc"
+	grpctest "github.com/hashicorp/go-plugin/test/grpc"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
@@ -455,6 +455,7 @@ func TestHelperProcess(*testing.T) {
 		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
 		os.Stderr.WriteString("[\"HELLO\"]\n")
 		os.Stderr.WriteString("12345\n")
+		os.Stderr.WriteString("{\"a\":1}\n")
 	case "stdin":
 		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
 		data := make([]byte, 5)


### PR DESCRIPTION
Don't drop json output if it's missing a log level. Log the original
line rather than as key-value data, since it likely wasn't intended for
hclog. Even if plugins try to avoid sending raw json objects, it's hard
to avoid if they are writing strings containing newlines (e.g. http
responses), which will be broken into multiple messages by the plugin
client.

Most plugins using go-plugin were previously using the convention of
prefixing log lines with the log level as `[LEVEL]`. Use these prefixes
if available to set the log level.