### PR TITLE
listener/tcp: better handling of min/max port env vars

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -61,3 +61,16 @@ Where:
     is omitted (older versions), this is "netrpc" for Go net/rpc. This can
     also be "grpc". This is the protocol that the plugin wants to speak to
     the host process with.
+
+## Environment Variables
+
+When serving a plugin over TCP, the following environment variables can be
+specified to restrict the port that will be assigned to be from within a
+specific range. If not values are provided, the port will be randomly assigned
+by the operating system.
+
+ * `PLUGIN_MIN_PORT`: Specifies the minimum port value that will be assigned to
+ * the listener.
+ 
+ * `PLUGIN_MAX_PORT`: Specifies the maximum port value that will be assigned to
+ * the listener.

--- a/server.go
+++ b/server.go
@@ -375,7 +375,7 @@ func serverListener_tcp() (net.Listener, error) {
 	default:
 		minPort, err = strconv.ParseInt(envMinPort, 10, 32)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Couldn't get value from PLUGIN_MIN_PORT: %v", err)
 		}
 	}
 
@@ -385,7 +385,7 @@ func serverListener_tcp() (net.Listener, error) {
 	default:
 		maxPort, err = strconv.ParseInt(envMaxPort, 10, 32)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Couldn't get value from PLUGIN_MAX_PORT: %v", err)
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -363,14 +363,34 @@ func serverListener() (net.Listener, error) {
 }
 
 func serverListener_tcp() (net.Listener, error) {
-	minPort, err := strconv.ParseInt(os.Getenv("PLUGIN_MIN_PORT"), 10, 32)
-	if err != nil {
-		return nil, err
+	envMinPort := os.Getenv("PLUGIN_MIN_PORT")
+	envMaxPort := os.Getenv("PLUGIN_MAX_PORT")
+
+	var minPort, maxPort int64
+	var err error
+
+	switch {
+	case len(envMinPort) == 0:
+		minPort = 0
+	default:
+		minPort, err = strconv.ParseInt(envMinPort, 10, 32)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	maxPort, err := strconv.ParseInt(os.Getenv("PLUGIN_MAX_PORT"), 10, 32)
-	if err != nil {
-		return nil, err
+	switch {
+	case len(envMaxPort) == 0:
+		maxPort = 0
+	default:
+		maxPort, err = strconv.ParseInt(envMaxPort, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if minPort > maxPort {
+		return nil, fmt.Errorf("ENV_MIN_PORT value of %d is greater than PLUGIN_MAX_PORT value of %d", minPort, maxPort)
 	}
 
 	for port := minPort; port <= maxPort; port++ {


### PR DESCRIPTION
This PR addresses the case where `PLUGIN_MIN_PORT` and/or `PLUGIN_MAX_PORT` are not set and thus treated as empty strings. In this case, `strconv.ParseInt` will error and and the plugin will fail to run.

This PR sets those values as 0 if not provided and lets the OS handle the port assignment (by effectively giving it an address of `127.0.0.1:0`). It also handles the case where the min port might be provided as a value larger than the max port, which would skip listener instantiation and error with "Couldn't bind plugin TCP listener".

Related to https://github.com/hashicorp/vault/issues/6587