### PR TITLE
fix text log level checks

### DIFF
--- a/client.go
+++ b/client.go
@@ -976,15 +976,15 @@ func (c *Client) logStderr(r io.Reader) {
 			// Attempt to infer the desired log level from the commonly used
 			// string prefixes
 			switch line := string(line); {
-			case strings.HasPrefix("[TRACE]", line):
+			case strings.HasPrefix(line, "[TRACE]"):
 				l.Trace(line)
-			case strings.HasPrefix("[DEBUG]", line):
+			case strings.HasPrefix(line, "[DEBUG]"):
 				l.Debug(line)
-			case strings.HasPrefix("[INFO]", line):
+			case strings.HasPrefix(line, "[INFO]"):
 				l.Info(line)
-			case strings.HasPrefix("[WARN]", line):
+			case strings.HasPrefix(line, "[WARN]"):
 				l.Warn(line)
-			case strings.HasPrefix("[ERROR]", line):
+			case strings.HasPrefix(line, "[ERROR]"):
 				l.Error(line)
 			default:
 				l.Debug(line)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -456,6 +456,10 @@ func TestHelperProcess(*testing.T) {
 		os.Stderr.WriteString("[\"HELLO\"]\n")
 		os.Stderr.WriteString("12345\n")
 		os.Stderr.WriteString("{\"a\":1}\n")
+	case "level-warn-text":
+		// write values that might be JSON, but aren't KVs
+		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
+		os.Stderr.WriteString("[WARN] test line 98765\n")
 	case "stdin":
 		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
 		data := make([]byte, 5)


### PR DESCRIPTION
The prefix checks were reversed in #106.
Add another test checking a less inclusive log level.