### PR TITLE
Return a meaningful reattach error for non-existent pids on Windows

### DIFF
--- a/client.go
+++ b/client.go
@@ -788,7 +788,10 @@ func (c *Client) reattach() (net.Addr, error) {
 	// Verify the process still exists. If not, then it is an error
 	p, err := os.FindProcess(c.config.Reattach.Pid)
 	if err != nil {
-		return nil, err
+		// On Unix systems, FindProcess never returns an error.
+		// On Windows, for non-existent pids it returns:
+		// os.SyscallError - 'OpenProcess: the paremter is incorrect'
+		return nil, ErrProcessNotFound
 	}
 
 	// Attempt to connect to the addr since on Unix systems FindProcess


### PR DESCRIPTION
This fix causes no change in behavior on Unix systems, and only
affects the error return type from reattach() when the reattach data
provided has a non-existent pid on Windows.

With this change in place, reattach() will now consistently return
ErrProcessNotFound on both Windows and Unix systems when the process
is indeed not found.

I encountered this while writing a Windows Nomad Task Driver plugin,
here's more context from the Nomad perspective:

The Reattach info Nomad stores can get stale, whereby the pid no
longer refers to a live process.

This has happened to me regularly (but not always) when
troubleshooting plugin development as I'm testingn what happens when
Nomad is forcefully killed and restarted.

On Windows, when the go-plugin code calls FindProcess with as stale
pid, the following error is always returned:
os.SyscallError - 'OpenProcess: the paremter is incorrect'

On Unix systems, FindProcess never returns an error, at least as
presently defined in the go source code.

In order for Nomad to recognize this condition we need to bubble up
the ErrProcesNotFound error, with which we can then futher propogate
the SingletonPluginExited error from singleton.go.

With these changes in place, whenever a stale pid is found in the
Reattach info, Nomad now properly restarts the plugin exe.