### PR TITLE
Start the plugin using the configured stdin, if available

### DIFF
--- a/client.go
+++ b/client.go
@@ -526,7 +526,11 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	cmd := c.config.Cmd
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Env = append(cmd.Env, env...)
-	cmd.Stdin = os.Stdin
+
+	// Use the client's stdin if configured, otherwise fallback to os.stdin
+	if cmd.Stdin == nil {
+		cmd.Stdin = os.Stdin
+	}
 
 	cmdStdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -728,11 +728,8 @@ func TestClient_Stdin(t *testing.T) {
 		t.Fatalf("error: %s", err)
 	}
 
-	oldStdin := os.Stdin
-	defer func() { os.Stdin = oldStdin }()
-	os.Stdin = tf
-
 	process := helperProcess("stdin")
+	process.Stdin = tf
 	c := NewClient(&ClientConfig{
 		Cmd:             process,
 		HandshakeConfig: testHandshake,


### PR DESCRIPTION
## What is the change?
When the `Cmd` struct already has `stdin` already configured, use that instead of `os.Stdin` when starting a plugin.

## Why?
I wanted to pass data to my plugins to assist with initialization, passing one-time configuration data that isn't part of the interface used to communicate with the plugin. I was having trouble getting this sent properly via `os.Stdin` honestly... 😊 

This seems like an improvement because it doesn't require remembering the original `os.Stdin` and swapping it back, and makes it easier for the host to pass a different stdin to a plugin, or mock it out for a test.