### PR TITLE
Handle stdio service not implemented

### DIFF
--- a/grpc_stdio.go
+++ b/grpc_stdio.go
@@ -7,12 +7,11 @@ import (
 	"io"
 
 	empty "github.com/golang/protobuf/ptypes/empty"
-	"github.com/hashicorp/go-hclog"
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin/internal/plugin"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/hashicorp/go-plugin/internal/plugin"
 )
 
 // grpcStdioBuffer is the buffer size we try to fill when sending a chunk of
@@ -101,10 +100,10 @@ func newGRPCStdioClient(
 	// Connect immediately to the endpoint
 	stdioClient, err := client.StreamStdio(ctx, &empty.Empty{})
 
-	// If we get an Unavailable error, this means that the plugin isn't
+	// If we get an Unavailable or Unimplemented error, this means that the plugin isn't
 	// updated and linking to the latest version of go-plugin that supports
 	// this. We fall back to the previous behavior of just not syncing anything.
-	if status.Code(err) == codes.Unavailable {
+	if status.Code(err) == codes.Unavailable || status.Code(err) == codes.Unimplemented {
 		log.Warn("stdio service not available, stdout/stderr syncing unavailable")
 		stdioClient = nil
 		err = nil
@@ -135,6 +134,7 @@ func (c *grpcStdioClient) Run(stdout, stderr io.Writer) {
 			if err == io.EOF ||
 				status.Code(err) == codes.Unavailable ||
 				status.Code(err) == codes.Canceled ||
+				status.Code(err) == codes.Unimplemented ||
 				err == context.Canceled {
 				c.log.Warn("received EOF, stopping recv loop", "err", err)
 				return


### PR DESCRIPTION
Fixes regression introduced by #135 when client uses latest version of this package and plugin is compiled with earlier version.

Before this fix, my client log were flooded with the following messages:
```
DBUG[04-07|14:04:20] waiting for stdio data
EROR[04-07|14:04:20] error receiving data err="rpc error: code = Unimplemented desc = unknown service plugin.GRPCStdio"
```

With these fixes I only receive the following warning message when plugin starts:
```
DBUG[04-07|14:04:20] waiting for stdio data
WARN[04-07|14:04:20] received EOF, stopping recv loop  err="rpc error: code = Unimplemented desc = unknown service plugin.GRPCStdio"
```