### PR TITLE
ServeConfig supports a manual listener

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -56,6 +56,39 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestClient_manualListener(t *testing.T) {
+	process := helperProcess("test-grpc-manual-listener")
+	c := NewClient(&ClientConfig{
+		Cmd:              process,
+		HandshakeConfig:  testHandshake,
+		Plugins:          testGRPCPluginMap,
+		AllowedProtocols: []Protocol{ProtocolGRPC},
+	})
+	defer c.Kill()
+
+	// Test that it parses the proper address
+	addr, err := c.Start()
+	if err != nil {
+		t.Fatalf("err should be nil, got %s", err)
+	}
+
+	if addr.Network() != "tcp" {
+		t.Fatalf("bad: %#v", addr)
+	}
+
+	if addr.String() != "127.0.0.1:1234" {
+		t.Fatalf("bad: %#v", addr)
+	}
+
+	// Test that it exits properly if killed
+	c.Kill()
+
+	// Test that it knows it is exited
+	if !c.Exited() {
+		t.Fatal("should say client has exited")
+	}
+}
+
 // This tests a bug where Kill would start
 func TestClient_killStart(t *testing.T) {
 	// Create a temporary dir to store the result file

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/rpc"
 	"os"
 	"os/exec"
@@ -547,6 +548,22 @@ func TestHelperProcess(*testing.T) {
 			Plugins:         testGRPCPluginMap,
 			GRPCServer:      DefaultGRPCServer,
 			TLSProvider:     helperTLSProvider,
+		})
+
+		// Shouldn't reach here but make sure we exit anyways
+		os.Exit(0)
+	case "test-grpc-manual-listener":
+		ln, err := net.Listen("tcp", "127.0.0.1:1234")
+		if err != nil {
+			panic(err)
+		}
+		defer ln.Close()
+
+		Serve(&ServeConfig{
+			HandshakeConfig: testHandshake,
+			Plugins:         testGRPCPluginMap,
+			GRPCServer:      DefaultGRPCServer,
+			Listener:        ln,
 		})
 
 		// Shouldn't reach here but make sure we exit anyways

--- a/server.go
+++ b/server.go
@@ -383,6 +383,11 @@ func Serve(opts *ServeConfig) {
 
 	// Accept connections and wait for completion
 	go server.Serve(listener)
+
+	// Note that given the documentation of Serve we should probably be
+	// setting exitCode = 0 and using os.Exit here. That's how it used to
+	// work before extracting this library. However, for years we've done
+	// this so we'll keep this functionality.
 	<-doneCh
 }
 


### PR DESCRIPTION
This lets the plugin more carefully control the address it wants to
listen on. This is an advanced use case and not typically necessary.
However, it has its uses if you want to force a plugin to serve on a
specific network.