### PR TITLE
grpc stream errors are terminal

### DIFF
--- a/grpc_stdio.go
+++ b/grpc_stdio.go
@@ -136,12 +136,12 @@ func (c *grpcStdioClient) Run(stdout, stderr io.Writer) {
 				status.Code(err) == codes.Canceled ||
 				status.Code(err) == codes.Unimplemented ||
 				err == context.Canceled {
-				c.log.Warn("received EOF, stopping recv loop", "err", err)
+				c.log.Debug("received EOF, stopping recv loop", "err", err)
 				return
 			}
 
 			c.log.Error("error receiving data", "err", err)
-			continue
+			return
 		}
 
 		// Determine our output writer based on channel


### PR DESCRIPTION
Return after all grpc stream errors in in the stdio client, as any
stream error is final.

Reduce EOF exit log to DEBUG. This case is unavoidable, and causes
unnecessary log noise.