### PR TITLE
Allow overriding ambient environment variables

### DIFF
--- a/client.go
+++ b/client.go
@@ -524,7 +524,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	}
 
 	cmd := c.config.Cmd
-	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Env = append(os.Environ(), cmd.Env...)
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Stdin = os.Stdin
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -11,6 +11,7 @@ import (
 	"net/rpc"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -469,6 +470,14 @@ func TestHelperProcess(*testing.T) {
 		}
 
 		if string(data) == "hello" {
+			os.Exit(0)
+		}
+
+		os.Exit(1)
+	case "env-vars":
+		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
+		p := os.Getenv("PATH")
+		if strings.Contains(p, "/go-plugins-path-override") {
 			os.Exit(0)
 		}
 


### PR DESCRIPTION
Change when os.Environ() is applied so that the environment variables explicitly set on the plugin command take precedence over ambient environment variables.

Fixes #162 