### PR TITLE
Add DialOptions field to Config struct

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,7 +22,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc"
 )
 
 // If this is 1, then we've called CleanupClients. This can be used
@@ -203,6 +204,10 @@ type ClientConfig struct {
 	//
 	// You cannot Reattach to a server with this option enabled.
 	AutoMTLS bool
+
+	// DialOptions allows plugin users to pass custom grpc.DialOption
+	// to create connections
+	DialOptions []grpc.DialOption
 }
 
 // ReattachConfig is used to configure a client to reattach to an

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -14,9 +14,9 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-func dialGRPCConn(tls *tls.Config, dialer func(string, time.Duration) (net.Conn, error)) (*grpc.ClientConn, error) {
+func dialGRPCConn(tls *tls.Config, dialer func(string, time.Duration) (net.Conn, error), dialOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	// Build dialing options.
-	opts := make([]grpc.DialOption, 0, 5)
+	opts := make([]grpc.DialOption, 0)
 
 	// We use a custom dialer so that we can connect over unix domain sockets.
 	opts = append(opts, grpc.WithDialer(dialer))
@@ -37,6 +37,8 @@ func dialGRPCConn(tls *tls.Config, dialer func(string, time.Duration) (net.Conn,
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
 		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(math.MaxInt32)))
 
+	opts = append(opts, dialOpts...)
+
 	// Connect. Note the first parameter is unused because we use a custom
 	// dialer that has the state to see the address.
 	conn, err := grpc.Dial("unused", opts...)
@@ -50,7 +52,7 @@ func dialGRPCConn(tls *tls.Config, dialer func(string, time.Duration) (net.Conn,
 // newGRPCClient creates a new GRPCClient. The Client argument is expected
 // to be successfully started already with a lock held.
 func newGRPCClient(doneCtx context.Context, c *Client) (*GRPCClient, error) {
-	conn, err := dialGRPCConn(c.config.TLSConfig, c.dialer)
+	conn, err := dialGRPCConn(c.config.TLSConfig, c.dialer, c.config.DialOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Megrez Lu <lujiajing1126@gmail.com>

Resolve issue #166 

## Motivation

In order to connect the inter-process traces between implementations of `go-plugin` and its peer services, we have to inject the existing tracing context from the client side while extracting context should also be done from the server side.

## Design



### Server Side

No necessary since we can already do the following, (excerpted from `jaeger` plugin from our private repository) 

```go
			grpc.ServeWithGRPCServer(
				store.NewAliyunSLSStore(&appConfig, logger),
				func(options []googleGRPC.ServerOption) *googleGRPC.Server {
					return plugin.DefaultGRPCServer([]googleGRPC.ServerOption{
						googleGRPC.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer)),
						googleGRPC.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer)),
					})
				},
			)
```

### Client Side

The only possibility to inject the tracing context is to add `grpc.UnaryClientInterceptor` or `grpc.StreamClientInterceptor` as an extra `DialOption` following the idea from `grpc-opentracing`,

https://github.com/grpc-ecosystem/grpc-opentracing/blob/master/go/otgrpc/client.go

```
// OpenTracingClientInterceptor returns a grpc.UnaryClientInterceptor suitable
// for use in a grpc.Dial call.
//
// For example:
//
//     conn, err := grpc.Dial(
//         address,
//         ...,  // (existing DialOptions)
//         grpc.WithUnaryInterceptor(otgrpc.OpenTracingClientInterceptor(tracer)))
//
// All gRPC client spans will inject the OpenTracing SpanContext into the gRPC
// metadata; they will also look in the context.Context for an active
// in-process parent Span and establish a ChildOf reference if such a parent
// Span could be found.
```

## Comments

I am not sure about the `Broker` module.