### PR TITLE
add ProtocolVersion to ReattachConfig

### DIFF
--- a/client.go
+++ b/client.go
@@ -209,9 +209,10 @@ type ClientConfig struct {
 // already-running plugin process. You can retrieve this information by
 // calling ReattachConfig on Client.
 type ReattachConfig struct {
-	Protocol Protocol
-	Addr     net.Addr
-	Pid      int
+	Protocol        Protocol
+	ProtocolVersion int
+	Addr            net.Addr
+	Pid             int
 
 	// Test is set to true if this is reattaching to to a plugin in "test mode"
 	// (see ServeConfig.Test). In this mode, client.Kill will NOT kill the
@@ -838,6 +839,7 @@ func (c *Client) reattach() (net.Addr, error) {
 		// Default the protocol to net/rpc for backwards compatibility
 		c.protocol = ProtocolNetRPC
 	}
+	c.negotiatedVersion = c.config.Reattach.ProtocolVersion
 
 	// If we're in test mode, we do NOT set the process. This avoids the
 	// process being killed (the only purpose we have for c.process), since

--- a/client.go
+++ b/client.go
@@ -839,7 +839,10 @@ func (c *Client) reattach() (net.Addr, error) {
 		// Default the protocol to net/rpc for backwards compatibility
 		c.protocol = ProtocolNetRPC
 	}
-	c.negotiatedVersion = c.config.Reattach.ProtocolVersion
+
+	if c.config.Reattach.Test {
+		c.negotiatedVersion = c.config.Reattach.ProtocolVersion
+	}
 
 	// If we're in test mode, we do NOT set the process. This avoids the
 	// process being killed (the only purpose we have for c.process), since

--- a/server.go
+++ b/server.go
@@ -415,10 +415,11 @@ func Serve(opts *ServeConfig) {
 		// quite ready if they connect immediately but the client should
 		// retry a few times.
 		ch <- &ReattachConfig{
-			Protocol: protoType,
-			Addr:     listener.Addr(),
-			Pid:      os.Getpid(),
-			Test:     true,
+			Protocol:        protoType,
+			ProtocolVersion: protoVersion,
+			Addr:            listener.Addr(),
+			Pid:             os.Getpid(),
+			Test:            true,
 		}
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -42,6 +42,11 @@ func TestServer_testMode(t *testing.T) {
 		t.Fatal("config should not be nil")
 	}
 
+	// Check that the reattach config includes the negotiated protocol version
+	if config.ProtocolVersion != int(testHandshake.ProtocolVersion) {
+		t.Fatalf("wrong protocol version in reattach config. got %d, expected %d", config.ProtocolVersion, testHandshake.ProtocolVersion)
+	}
+
 	// Connect!
 	c := NewClient(&ClientConfig{
 		Cmd:              nil,


### PR DESCRIPTION
This PR adds the (already-determined) `ProtocolVersion` to `ReattachConfig`. This information was not captured previously, so a caller connecting to a running process had no way of knowing what `ProtocolVersion` had been negotiated:  `client.NegotiatedVersion` would always return `0`.