### PR TITLE
fix: typo in plugin name

### DIFF
--- a/examples/grpc/main.go
+++ b/examples/grpc/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	// Request the plugin
-	raw, err := rpcClient.Dispense("kv_grpc")
+	raw, err := rpcClient.Dispense("kv")
 	if err != nil {
 		fmt.Println("Error:", err.Error())
 		os.Exit(1)


### PR DESCRIPTION
The example didn't work for me because the plugins register name "kv" but the main code expected "kv_grpc".

Changing the name to "kv" here fixed the examples for me.