### PR TITLE
Allow bidirectional communication with AutoTLS enabled 

### DIFF
--- a/server.go
+++ b/server.go
@@ -318,7 +318,9 @@ func Serve(opts *ServeConfig) {
 			Certificates: []tls.Certificate{cert},
 			ClientAuth:   tls.RequireAndVerifyClientCert,
 			ClientCAs:    clientCertPool,
+			RootCAs:      clientCertPool,
 			MinVersion:   tls.VersionTLS12,
+			ServerName:   "localhost",
 		}
 
 		// We send back the raw leaf cert data for the client rather than the


### PR DESCRIPTION
Currently enabling AutoTLS when connecting from a plugin back to host ends with `transport: authentication handshake failed: x509: certificate is valid for localhost, not unused` as described in #109. 
This PR sets ServerName and RootCAs in `tls.Config` on the server-side with the certificate received from the host. This allows to successfully establish the connection.

Fixes #109 