### PR TITLE
Add `ProtocolVersionError` type with client/server versions

### DIFF
--- a/client.go
+++ b/client.go
@@ -883,8 +883,20 @@ func (c *Client) checkProtoVersion(protoVersion string) (int, PluginSet, error) 
 		return version, plugins, nil
 	}
 
-	return 0, nil, fmt.Errorf("Incompatible API version with plugin. "+
-		"Plugin version: %d, Client versions: %d", serverVersion, clientVersions)
+	return 0, nil, &ProtocolVersionError{
+		ClientVersions: clientVersions,
+		ServerVersion:  serverVersion,
+	}
+}
+
+type ProtocolVersionError struct {
+	ClientVersions []int
+	ServerVersion  int
+}
+
+func (e *ProtocolVersionError) Error() string {
+	return fmt.Sprintf("Incompatible API version with plugin. "+
+		"Plugin version: %d, Client versions: %d", e.ServerVersion, e.ClientVersions)
 }
 
 // ReattachConfig returns the information that must be provided to NewClient

--- a/client_test.go
+++ b/client_test.go
@@ -622,6 +622,15 @@ func TestClientStart_badNegotiatedVersion(t *testing.T) {
 		t.Fatal("err should not be nil")
 	}
 	fmt.Println(err)
+
+	versionErr, ok := err.(*ProtocolVersionError)
+	if !ok {
+		t.Fatal("err should be a ProtocolVersionError")
+	}
+
+	if versionErr.ServerVersion != 2 {
+		t.Fatalf("expected server version 2, got: %d", versionErr.ServerVersion)
+	}
 }
 
 func TestClient_Start_Timeout(t *testing.T) {


### PR DESCRIPTION
This adds a `ProtocolVersionError` error type that is returned when encountering a client/server plugin API mismatch. This `error` exposes the `ClientVersions` and `ServerVersions`. The error string remains the same as it is currently. 

This provides a mechanism for plugin authors to implement custom messaging around version mismatches. For example, if the plugin server version is greater than the offered client versions, you could tell the user "upgrade the client or downgrade the plugin."

See https://github.com/terraform-linters/tflint/issues/1341 for an example of the issues that come up when protocol iterations are semi-frequent. And https://github.com/terraform-linters/tflint/blob/bf80af29756b3de976871360d3574879f5eddec0/plugin/discovery.go#L137-L156 for a hack that was put in place to try to wrap this error.

Since the code is so simple I figured I'd offer this. Happy to work on other approaches as well.