### PR TITLE
Update client to prioritize supplied Env over os.Environ

### DIFF
--- a/client.go
+++ b/client.go
@@ -534,7 +534,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	}
 
 	cmd := c.config.Cmd
-	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Env = append(os.Environ(), cmd.Env...)
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Stdin = os.Stdin
 


### PR DESCRIPTION
Client-supplied environment variables should have priority over the current environment, but they're currently overwritten. 

The go stdlib deduplicates by removing the first key value pairs in `Command.Env` when executing a command, so changing the order of how we append it fixes this problem.

https://github.com/golang/go/blob/master/src/os/exec/exec.go#L158
https://github.com/golang/go/blob/master/src/os/exec/exec.go#L910

