### PR TITLE
client: log warning when SecureConfig is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.4.5
+
+ENHANCEMENTS:
+
+* client: log warning when SecureConfig is nil [[GH-207](https://github.com/hashicorp/go-plugin/pull/207)]
+
+
 ## v1.4.4
 
 ENHANCEMENTS:

--- a/client.go
+++ b/client.go
@@ -547,7 +547,9 @@ func (c *Client) Start() (addr net.Addr, err error) {
 		return nil, err
 	}
 
-	if c.config.SecureConfig != nil {
+	if c.config.SecureConfig == nil {
+		c.logger.Warn("plugin configured with a nil SecureConfig")
+	} else {
 		if ok, err := c.config.SecureConfig.Check(cmd.Path); err != nil {
 			return nil, fmt.Errorf("error verifying checksum: %s", err)
 		} else if !ok {


### PR DESCRIPTION
so that it is obvious when looking back over the logs as to why your plugin checksum was not validated.