### PR TITLE
Fix examples/basic/commons go package name

### DIFF
--- a/docs/extensive-go-plugin-tutorial.md
+++ b/docs/extensive-go-plugin-tutorial.md
@@ -90,7 +90,7 @@ And last but not least is the `Plugins` map. This map is used in order to identi
 
 ~~~go
 // pluginMap is the map of plugins we can dispense.
-var pluginMap = map[string]plugin.Plugin{"greeter": &example.GreeterPlugin{}}
+var pluginMap = map[string]plugin.Plugin{"greeter": &shared.GreeterPlugin{}}
 ~~~
 
 You can see that the key is the name of the plugin and the value is the plugin.
@@ -126,7 +126,7 @@ Now, the magic:
 ~~~go
 	// We should have a Greeter now! This feels like a normal interface
 	// implementation but is in fact over an RPC connection.
-	greeter := raw.(example.Greeter)
+	greeter := raw.(shared.Greeter)
 	fmt.Println(greeter.Greet())
 ~~~
 
@@ -277,7 +277,7 @@ greeter := &GreeterHello{
 }
 // pluginMap is the map of plugins we can dispense.
 var pluginMap = map[string]plugin.Plugin{
-    "greeter": &example.GreeterPlugin{Impl: greeter},
+    "greeter": &shared.GreeterPlugin{Impl: greeter},
 }
 
 logger.Debug("message from plugin", "foo", "bar")

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -8,7 +8,7 @@ import (
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-plugin/examples/basic/commons"
+	"github.com/hashicorp/go-plugin/examples/basic/shared"
 )
 
 func main() {
@@ -42,7 +42,7 @@ func main() {
 
 	// We should have a Greeter now! This feels like a normal interface
 	// implementation but is in fact over an RPC connection.
-	greeter := raw.(example.Greeter)
+	greeter := raw.(shared.Greeter)
 	fmt.Println(greeter.Greet())
 }
 
@@ -58,5 +58,5 @@ var handshakeConfig = plugin.HandshakeConfig{
 
 // pluginMap is the map of plugins we can dispense.
 var pluginMap = map[string]plugin.Plugin{
-	"greeter": &example.GreeterPlugin{},
+	"greeter": &shared.GreeterPlugin{},
 }

--- a/examples/basic/plugin/greeter_impl.go
+++ b/examples/basic/plugin/greeter_impl.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-plugin/examples/basic/commons"
+	"github.com/hashicorp/go-plugin/examples/basic/shared"
 )
 
 // Here is a real implementation of Greeter
@@ -40,7 +40,7 @@ func main() {
 	}
 	// pluginMap is the map of plugins we can dispense.
 	var pluginMap = map[string]plugin.Plugin{
-		"greeter": &example.GreeterPlugin{Impl: greeter},
+		"greeter": &shared.GreeterPlugin{Impl: greeter},
 	}
 
 	logger.Debug("message from plugin", "foo", "bar")

--- a/examples/basic/shared/greeter_interface.go
+++ b/examples/basic/shared/greeter_interface.go
@@ -1,4 +1,4 @@
-package example
+package shared
 
 import (
 	"net/rpc"


### PR DESCRIPTION
Fix examples/basic/commons go package name

Package name "commons" is more explicit in "commons" dir than "example".