### PR TITLE
RPCServer: close chan when Serve returns

### DIFF
--- a/rpc_server.go
+++ b/rpc_server.go
@@ -42,6 +42,8 @@ func (s *RPCServer) Config() string { return "" }
 
 // ServerProtocol impl.
 func (s *RPCServer) Serve(lis net.Listener) {
+	defer s.done()
+
 	for {
 		conn, err := lis.Accept()
 		if err != nil {
@@ -82,7 +84,7 @@ func (s *RPCServer) ServeConn(conn io.ReadWriteCloser) {
 
 	// Connect the stdstreams (in, out, err)
 	stdstream := make([]net.Conn, 2)
-	for i, _ := range stdstream {
+	for i := range stdstream {
 		stdstream[i], err = mux.Accept()
 		if err != nil {
 			mux.Close()
@@ -133,13 +135,15 @@ type controlServer struct {
 // Ping can be called to verify the connection (and likely the binary)
 // is still alive to a plugin.
 func (c *controlServer) Ping(
-	null bool, response *struct{}) error {
+	null bool, response *struct{},
+) error {
 	*response = struct{}{}
 	return nil
 }
 
 func (c *controlServer) Quit(
-	null bool, response *struct{}) error {
+	null bool, response *struct{},
+) error {
 	// End the server
 	c.server.done()
 
@@ -156,7 +160,8 @@ type dispenseServer struct {
 }
 
 func (d *dispenseServer) Dispense(
-	name string, response *uint32) error {
+	name string, response *uint32,
+) error {
 	// Find the function to create this implementation
 	p, ok := d.plugins[name]
 	if !ok {

--- a/server_test.go
+++ b/server_test.go
@@ -151,6 +151,37 @@ func TestServer_testMode_AutoMTLS(t *testing.T) {
 	<-closeCh
 }
 
+func TestServer_RPC(t *testing.T) {
+	closeCh := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// make a server, but we don't need to attach to it
+	ch := make(chan *ReattachConfig, 1)
+	go Serve(&ServeConfig{
+		HandshakeConfig: testHandshake,
+		Plugins:         testPluginMap,
+		Test: &ServeTestConfig{
+			Context:          ctx,
+			CloseCh:          closeCh,
+			ReattachConfigCh: ch,
+		},
+	})
+
+	// Wait for the server
+	select {
+	case cfg := <-ch:
+		if cfg == nil {
+			t.Fatal("attach config should not be nil")
+		}
+	case <-time.After(2000 * time.Millisecond):
+		t.Fatal("should've received reattach")
+	}
+
+	cancel()
+	<-closeCh
+}
+
 func TestRmListener_impl(t *testing.T) {
 	var _ net.Listener = new(rmListener)
 }


### PR DESCRIPTION
Ensure the RPCServer Serve function closes the DoneCh when it returns. Add a test that will hang if we don't close the channel.

Fixes https://github.com/hashicorp/go-plugin/issues/216

Log diff after changes using the [basic example](https://github.com/hashicorp/go-plugin/tree/master/examples/basic)
```diff
diff --git a/rpc.log b/rpc.log
index c7237c7..b8ca295 100644
--- a/rpc.log
+++ b/rpc.log
@@ -7,7 +7,6 @@
 [DEBUG] plugin: using plugin: version=1
 [DEBUG] plugin.greeter: message from GreeterHello.Greet: timestamp=NORMALIZED
 Hello!
-[DEBUG] plugin.greeter: NORMALIZED [ERR] plugin: stream copy 'stderr' error: stream closed
 [DEBUG] plugin.greeter: NORMALIZED [DEBUG] plugin: plugin server: accept unix NORMALIZED: use of closed network connection
 [INFO]  plugin: plugin process exited: path=./plugin/greeter pid=NORMALIZED
 [DEBUG] plugin: plugin exited
```


<Details>
<Summary>Test output</Summary>

```
Wed Oct 12 09:39:19 CDT 2022
--- PASS: TestClient_testInterfaceReattach (2.01s)
--- PASS: TestClient (0.01s)
--- PASS: TestClient_killStart (0.01s)
--- PASS: TestClient_testCleanup (0.01s)
--- PASS: TestClient_testInterface (0.01s)
--- PASS: TestClient_grpc_servercrash (0.01s)
--- PASS: TestClient_grpc (0.01s)
--- PASS: TestClient_grpcNotAllowed (0.01s)
--- PASS: TestClient_grpcSyncStdio (0.03s)
--- PASS: TestClient_cmdAndReattach (0.00s)
--- PASS: TestClient_reattach (1.01s)
--- PASS: TestClient_reattachNoProtocol (1.01s)
--- PASS: TestClient_reattachGRPC (1.01s)
--- PASS: TestClient_reattachNotFound (0.01s)
--- PASS: TestClientStart_badVersion (0.01s)
--- PASS: TestClientStart_badNegotiatedVersion (0.01s)
--- PASS: TestClient_Start_Timeout (0.05s)
--- PASS: TestClient_Stderr (0.02s)
--- PASS: TestClient_StderrJSON (0.02s)
--- PASS: TestClient_textLogLevel (0.02s)
--- PASS: TestClient_Stdin (0.09s)
--- PASS: TestClient_SecureConfig (0.10s)
--- PASS: TestClient_TLS (0.03s)
--- PASS: TestClient_TLS_grpc (0.02s)
--- PASS: TestClient_secureConfigAndReattach (0.00s)
--- PASS: TestClient_ping (0.01s)
--- PASS: TestClient_wrongVersion (0.01s)
--- PASS: TestClient_legacyClient (0.01s)
--- PASS: TestClient_legacyServer (2.01s)
--- PASS: TestClient_versionedClient (0.02s)
--- PASS: TestClient_mtlsClient (0.06s)
--- PASS: TestClient_mtlsNetRPCClient (0.05s)
--- PASS: TestClient_logger (0.43s)
--- PASS: TestClient_logStderr (0.00s)
--- PASS: TestBasicError_ImplementsError (0.00s)
--- PASS: TestBasicError_MatchesMessage (0.00s)
--- PASS: TestNewBasicError_nil (0.00s)
--- PASS: TestGRPCClient_App (0.00s)
--- PASS: TestGRPCConn_BidirectionalPing (0.00s)
--- PASS: TestGRPCC_Stream (0.00s)
--- PASS: TestGRPCClient_Ping (0.00s)
--- PASS: TestGRPCClient_Reflection (0.00s)
--- PASS: TestHelperProcess (0.00s)
--- PASS: TestClient_App (0.00s)
--- PASS: TestClient_syncStreams (0.10s)
--- PASS: TestServer_testMode (0.00s)
--- PASS: TestServer_RPC (0.00s)
--- PASS: TestServer_testMode_AutoMTLS (0.08s)
--- PASS: TestRmListener_impl (0.00s)
--- PASS: TestRmListener (0.00s)
--- PASS: TestProtocolSelection_no_server (0.00s)
--- PASS: TestServer_testStdLogger (0.00s)
ok  	github.com/hashicorp/go-plugin	9.010s
```
</Details>