### PR TITLE
fix: do not kill plugin process when use examples to test

### DIFF
--- a/examples/bidirectional/main.go
+++ b/examples/bidirectional/main.go
@@ -36,14 +36,14 @@ func main() {
 	rpcClient, err := client.Client()
 	if err != nil {
 		fmt.Println("Error:", err.Error())
-		os.Exit(1)
+		return
 	}
 
 	// Request the plugin
 	raw, err := rpcClient.Dispense("counter")
 	if err != nil {
 		fmt.Println("Error:", err.Error())
-		os.Exit(1)
+		return
 	}
 
 	// We should have a Counter store now! This feels like a normal interface
@@ -56,26 +56,23 @@ func main() {
 		result, err := counter.Get(os.Args[1])
 		if err != nil {
 			fmt.Println("Error:", err.Error())
-			os.Exit(1)
+			return
 		}
-
 		fmt.Println(result)
 
 	case "put":
 		i, err := strconv.Atoi(os.Args[2])
 		if err != nil {
 			fmt.Println("Error:", err.Error())
-			os.Exit(1)
+			return
 		}
 
 		err = counter.Put(os.Args[1], int64(i), &addHelper{})
 		if err != nil {
 			fmt.Println("Error:", err.Error())
-			os.Exit(1)
 		}
-
 	default:
 		fmt.Println("Please only use 'get' or 'put'")
-		os.Exit(1)
 	}
+	return
 }

--- a/examples/grpc/main.go
+++ b/examples/grpc/main.go
@@ -29,14 +29,14 @@ func main() {
 	rpcClient, err := client.Client()
 	if err != nil {
 		fmt.Println("Error:", err.Error())
-		os.Exit(1)
+		return
 	}
 
 	// Request the plugin
 	raw, err := rpcClient.Dispense("kv_grpc")
 	if err != nil {
 		fmt.Println("Error:", err.Error())
-		os.Exit(1)
+		return
 	}
 
 	// We should have a KV store now! This feels like a normal interface
@@ -48,21 +48,17 @@ func main() {
 		result, err := kv.Get(os.Args[1])
 		if err != nil {
 			fmt.Println("Error:", err.Error())
-			os.Exit(1)
+			return
 		}
-
 		fmt.Println(string(result))
 
 	case "put":
 		err := kv.Put(os.Args[1], []byte(os.Args[2]))
 		if err != nil {
 			fmt.Println("Error:", err.Error())
-			os.Exit(1)
 		}
-
 	default:
-		fmt.Printf("Please only use 'get' or 'put', given: %q", os.Args[0])
-		os.Exit(1)
+		fmt.Printf("Please only use 'get' or 'put', given: %q\n", os.Args[0])
 	}
-	os.Exit(0)
+	return
 }

--- a/examples/negotiated/main.go
+++ b/examples/negotiated/main.go
@@ -46,14 +46,14 @@ func main() {
 	rpcClient, err := client.Client()
 	if err != nil {
 		fmt.Println("Error:", err.Error())
-		os.Exit(1)
+		return
 	}
 
 	// Request the plugin
 	raw, err := rpcClient.Dispense("kv")
 	if err != nil {
 		fmt.Println("Error:", err.Error())
-		os.Exit(1)
+		return
 	}
 
 	// We should have a KV store now! This feels like a normal interface
@@ -65,20 +65,16 @@ func main() {
 		result, err := kv.Get(os.Args[1])
 		if err != nil {
 			fmt.Println("Error:", err.Error())
-			os.Exit(1)
+			return
 		}
-
 		fmt.Println(string(result))
 
 	case "put":
 		err := kv.Put(os.Args[1], []byte(os.Args[2]))
 		if err != nil {
 			fmt.Println("Error:", err.Error())
-			os.Exit(1)
 		}
-
 	default:
 		fmt.Println("Please only use 'get' or 'put'")
-		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Do not kill plugin process when use "examples" to test.

501 95990     1   0  5:19PM ttys023    0:00.01 ./kv-go-grpc
501 96014     1   0  5:19PM ttys023    0:00.01 ./kv-go-grpc
501 96038     1   0  5:19PM ttys023    0:00.01 ./kv-go-grpc
501 96064     1   0  5:19PM ttys023    0:00.01 ./kv-go-grpc
501 96088     1   0  5:19PM ttys023    0:00.01 ./kv-go-grpc
501 96112     1   0  5:19PM ttys023    0:00.01 ./kv-go-grpc
501 96138     1   0  5:19PM ttys023    0:00.01 ./kv-go-grpc
501 96166     1   0  5:19PM ttys023    0:00.01 ./kv-go-grpc
501 96190     1   0  5:19PM ttys023    0:00.01 ./kv-go-grpc
501 97047 95287   0  5:43PM ttys023    0:00.00 grep grpc
