### PR TITLE
Ensure GRPCServer.Stop() calls GRPCBroker.Close()

### DIFF
--- a/grpc_server.go
+++ b/grpc_server.go
@@ -107,8 +107,8 @@ func (s *GRPCServer) Init() error {
 	return nil
 }
 
-// Stop calls Close on the underlying grpc.Broker and Stop on the underlying
-// grpc.Server
+// Stop calls Stop on the underlying grpc.Server and Close on the underlying
+// grpc.Broker if present.
 func (s *GRPCServer) Stop() {
 	s.server.Stop()
 
@@ -118,7 +118,8 @@ func (s *GRPCServer) Stop() {
 	}
 }
 
-// GracefulStop calls GracefulStop on the underlying grpc.Server
+// GracefulStop calls GracefulStop on the underlying grpc.Server and Close on
+// the underlying grpc.Broker if present.
 func (s *GRPCServer) GracefulStop() {
 	s.server.GracefulStop()
 

--- a/grpc_server.go
+++ b/grpc_server.go
@@ -107,8 +107,12 @@ func (s *GRPCServer) Init() error {
 	return nil
 }
 
-// Stop calls Stop on the underlying grpc.Server
+// Stop calls Close on the underlying grpc.Broker and Stop on the underlying
+// grpc.Server
 func (s *GRPCServer) Stop() {
+	if s.broker != nil {
+		s.broker.Close()
+	}
 	s.server.Stop()
 }
 

--- a/grpc_server.go
+++ b/grpc_server.go
@@ -110,15 +110,22 @@ func (s *GRPCServer) Init() error {
 // Stop calls Close on the underlying grpc.Broker and Stop on the underlying
 // grpc.Server
 func (s *GRPCServer) Stop() {
+	s.server.Stop()
+
 	if s.broker != nil {
 		s.broker.Close()
+		s.broker = nil
 	}
-	s.server.Stop()
 }
 
 // GracefulStop calls GracefulStop on the underlying grpc.Server
 func (s *GRPCServer) GracefulStop() {
 	s.server.GracefulStop()
+
+	if s.broker != nil {
+		s.broker.Close()
+		s.broker = nil
+	}
 }
 
 // Config is the GRPCServerConfig encoded as JSON then base64.


### PR DESCRIPTION
Initializing a GRPCServer will do the following:

```go
	// Register the broker service
	brokerServer := newGRPCBrokerServer()
	plugin.RegisterGRPCBrokerServer(s.server, brokerServer)
	s.broker = newGRPCBroker(brokerServer, s.TLS)
	go s.broker.Run()
```

The current Stop() method omits any handling of the underlying `s.broker`, which means the broker goroutine will leak:

```text
        [Goroutine 53 in state select, with github.com/hashicorp/go-plugin.(*gRPCBrokerServer).Recv on top of the stack:
        goroutine 53 [select]:
        github.com/hashicorp/go-plugin.(*gRPCBrokerServer).Recv(0x29?)
                /Users/bflad/go/pkg/mod/github.com/hashicorp/go-plugin@v1.4.4/grpc_broker.go:121 +0x58
        github.com/hashicorp/go-plugin.(*GRPCBroker).Run(0x140003ca190)
                /Users/bflad/go/pkg/mod/github.com/hashicorp/go-plugin@v1.4.4/grpc_broker.go:411 +0x40
        created by github.com/hashicorp/go-plugin.(*GRPCServer).Init
                /Users/bflad/go/pkg/mod/github.com/hashicorp/go-plugin@v1.4.4/grpc_server.go:85 +0x424
        ]
```

If there is another/better way to handle these, please reach out.