### PR TITLE
remove logging for missing `SecureConfig`

### DIFF
--- a/client.go
+++ b/client.go
@@ -568,9 +568,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 		return nil, err
 	}
 
-	if c.config.SecureConfig == nil {
-		c.logger.Warn("plugin configured with a nil SecureConfig")
-	} else {
+	if c.config.SecureConfig != nil {
 		if ok, err := c.config.SecureConfig.Check(cmd.Path); err != nil {
 			return nil, fmt.Errorf("error verifying checksum: %s", err)
 		} else if !ok {


### PR DESCRIPTION
In #207 we introduced a warning if the `SecureConfig` is unset. For Nomad and other applications that have "internal" go-plugin consumers where the application runs itself as a plugin, this causes spurious warn-level logs. For Nomad in particular this means every task driver and logmon invocation emits the log, which is our primary operation.

Setting a `SecureConfig` isn't required, and if a given go-plugin consumer requires it to be, this seems more like a programming error than a runtime error. Remove the log line.

Ref https://github.com/hashicorp/nomad/issues/16288