### PR TITLE
deps: Remove direct dependency on golang.org/x/net

### DIFF
--- a/examples/bidirectional/proto/kv.pb.go
+++ b/examples/bidirectional/proto/kv.pb.go
@@ -22,7 +22,7 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/examples/bidirectional/shared/grpc.go
+++ b/examples/bidirectional/shared/grpc.go
@@ -1,10 +1,11 @@
 package shared
 
 import (
+	"context"
+
 	hclog "github.com/hashicorp/go-hclog"
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/go-plugin/examples/bidirectional/proto"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/examples/bidirectional/shared/interface.go
+++ b/examples/bidirectional/shared/interface.go
@@ -2,7 +2,8 @@
 package shared
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/go-plugin"

--- a/examples/grpc/proto/kv.pb.go
+++ b/examples/grpc/proto/kv.pb.go
@@ -20,7 +20,7 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/examples/grpc/shared/grpc.go
+++ b/examples/grpc/shared/grpc.go
@@ -1,8 +1,9 @@
 package shared
 
 import (
+	"context"
+
 	"github.com/hashicorp/go-plugin/examples/grpc/proto"
-	"golang.org/x/net/context"
 )
 
 // GRPCClient is an implementation of KV that talks over RPC.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/jhump/protoreflect v1.6.0
 	github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77
 	github.com/oklog/run v1.0.0
-	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	google.golang.org/grpc v1.27.1
 )
 
@@ -18,6 +17,7 @@ require (
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
 	golang.org/x/sys v0.0.0-20191008105621-543471e840be // indirect
 	golang.org/x/text v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"math"
@@ -8,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-plugin/internal/plugin"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"

--- a/internal/plugin/grpc_broker.pb.go
+++ b/internal/plugin/grpc_broker.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/internal/plugin/grpc_controller.pb.go
+++ b/internal/plugin/grpc_controller.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/internal/plugin/grpc_stdio.pb.go
+++ b/internal/plugin/grpc_stdio.pb.go
@@ -9,7 +9,7 @@ import math "math"
 import empty "github.com/golang/protobuf/ptypes/empty"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -17,7 +18,6 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	hclog "github.com/hashicorp/go-hclog"
 	grpctest "github.com/hashicorp/go-plugin/test/grpc"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/test/grpc/test.pb.go
+++ b/test/grpc/test.pb.go
@@ -9,7 +9,7 @@ import math "math"
 import empty "github.com/golang/protobuf/ptypes/empty"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
Reference: https://pkg.go.dev/golang.org/x/net@v0.0.0-20190311183353-d8887717615a/context
Reference: https://github.com/hashicorp/go-plugin/pull/186

Previously, the module was only using `golang.org/x/net/context` import. That package was deprecated with Go 1.7 when its functionality migrated into the standard library `context` package. This Go module already announces Go 1.17 minimum since version 1.4.4 and the `context` types are not exposed as part of any exported API.