### PR TITLE
add DialOptions to GRPCBroker's Dial

### DIFF
--- a/grpc_broker.go
+++ b/grpc_broker.go
@@ -367,7 +367,7 @@ func (b *GRPCBroker) Close() error {
 }
 
 // Dial opens a connection by ID.
-func (b *GRPCBroker) Dial(id uint32) (conn *grpc.ClientConn, err error) {
+func (b *GRPCBroker) Dial(id uint32, dialOpts ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
 	var c *plugin.ConnInfo
 
 	// Open the stream
@@ -392,7 +392,7 @@ func (b *GRPCBroker) Dial(id uint32) (conn *grpc.ClientConn, err error) {
 		return nil, err
 	}
 
-	return dialGRPCConn(b.tls, netAddrDialer(addr))
+	return dialGRPCConn(b.tls, netAddrDialer(addr), dialOpts...)
 }
 
 // NextId returns a unique ID to use next.


### PR DESCRIPTION
## Motivation 

Spiritual successor to : #168 

For purpose built client-side interceptors, there can be a need to control which plugins get certain interceptors and this currently isn't possible with `GRPCBroker`'s  `Dial(id uint32)` signature or using "global" dialOpts in the plugin [Client Config](https://github.com/hashicorp/go-plugin/blob/e889c1ba1044d1b183d4ed45d0f2f531db3ba50b/client.go#L222) struct (without changing existing plugin structures to use multiple client instances)

## Client-side change

The underlying [dial implementation](https://github.com/hashicorp/go-plugin/blob/e889c1ba1044d1b183d4ed45d0f2f531db3ba50b/grpc_client.go#L20) in  `Dial(id uint32)` accepts `...grpc.DialOption` so I propose : 

`Dial(id uint32, dialOpts ...grpc.DialOption)` for more fine grained control over GRPCBroker connections.