### PR TITLE
Revert "Add context argument to runner methods that do work"

### DIFF
--- a/client.go
+++ b/client.go
@@ -515,7 +515,7 @@ func (c *Client) Kill() {
 
 	// If graceful exiting failed, just kill it
 	c.logger.Warn("plugin failed to exit gracefully")
-	if err := runner.Kill(context.Background()); err != nil {
+	if err := runner.Kill(); err != nil {
 		c.logger.Debug("error killing plugin", "error", err)
 	}
 
@@ -668,9 +668,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	}
 
 	c.runner = runner
-	startCtx, startCtxCancel := context.WithTimeout(context.Background(), c.config.StartTimeout)
-	defer startCtxCancel()
-	err = runner.Start(startCtx)
+	err = runner.Start()
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +678,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 		rErr := recover()
 
 		if err != nil || rErr != nil {
-			runner.Kill(context.Background())
+			runner.Kill()
 		}
 
 		if rErr != nil {
@@ -709,7 +707,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 		c.stderrWaitGroup.Wait()
 
 		// Wait for the command to end.
-		err := runner.Wait(context.Background())
+		err := runner.Wait()
 		if err != nil {
 			c.logger.Error("plugin process exited", "plugin", runner.Name(), "id", runner.ID(), "error", err.Error())
 		} else {
@@ -901,7 +899,7 @@ func (c *Client) reattach() (net.Addr, error) {
 		defer c.ctxCancel()
 
 		// Wait for the process to die
-		r.Wait(context.Background())
+		r.Wait()
 
 		// Log so we can see it
 		c.logger.Debug("reattached plugin process exited")

--- a/client_test.go
+++ b/client_test.go
@@ -5,7 +5,6 @@ package plugin
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -227,7 +226,7 @@ func TestClient_grpc_servercrash(t *testing.T) {
 		t.Fatalf("bad: %#v", raw)
 	}
 
-	c.runner.Kill(context.Background())
+	c.runner.Kill()
 
 	select {
 	case <-c.doneCtx.Done():
@@ -1256,7 +1255,7 @@ func TestClient_versionedClient(t *testing.T) {
 		t.Fatalf("bad: %#v", raw)
 	}
 
-	c.runner.Kill(context.Background())
+	c.runner.Kill()
 
 	select {
 	case <-c.doneCtx.Done():
@@ -1312,7 +1311,7 @@ func TestClient_mtlsClient(t *testing.T) {
 		t.Fatal("invalid response", n)
 	}
 
-	c.runner.Kill(context.Background())
+	c.runner.Kill()
 
 	select {
 	case <-c.doneCtx.Done():
@@ -1358,7 +1357,7 @@ func TestClient_mtlsNetRPCClient(t *testing.T) {
 		t.Fatal("invalid response", n)
 	}
 
-	c.runner.Kill(context.Background())
+	c.runner.Kill()
 
 	select {
 	case <-c.doneCtx.Done():

--- a/internal/cmdrunner/cmd_reattach.go
+++ b/internal/cmdrunner/cmd_reattach.go
@@ -4,7 +4,6 @@
 package cmdrunner
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
@@ -50,11 +49,11 @@ type CmdAttachedRunner struct {
 	addrTranslator
 }
 
-func (c *CmdAttachedRunner) Wait(_ context.Context) error {
+func (c *CmdAttachedRunner) Wait() error {
 	return pidWait(c.pid)
 }
 
-func (c *CmdAttachedRunner) Kill(_ context.Context) error {
+func (c *CmdAttachedRunner) Kill() error {
 	return c.process.Kill()
 }
 

--- a/internal/cmdrunner/cmd_runner.go
+++ b/internal/cmdrunner/cmd_runner.go
@@ -4,7 +4,6 @@
 package cmdrunner
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -62,7 +61,7 @@ func NewCmdRunner(logger hclog.Logger, cmd *exec.Cmd) (*CmdRunner, error) {
 	}, nil
 }
 
-func (c *CmdRunner) Start(_ context.Context) error {
+func (c *CmdRunner) Start() error {
 	c.logger.Debug("starting plugin", "path", c.cmd.Path, "args", c.cmd.Args)
 	err := c.cmd.Start()
 	if err != nil {
@@ -74,11 +73,11 @@ func (c *CmdRunner) Start(_ context.Context) error {
 	return nil
 }
 
-func (c *CmdRunner) Wait(_ context.Context) error {
+func (c *CmdRunner) Wait() error {
 	return c.cmd.Wait()
 }
 
-func (c *CmdRunner) Kill(_ context.Context) error {
+func (c *CmdRunner) Kill() error {
 	if c.cmd.Process != nil {
 		err := c.cmd.Process.Kill()
 		// Swallow ErrProcessDone, we support calling Kill multiple times.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -4,7 +4,6 @@
 package runner
 
 import (
-	"context"
 	"io"
 )
 
@@ -12,11 +11,9 @@ import (
 // of a plugin and attempt to negotiate a connection with it. Note that this
 // is orthogonal to the protocol and transport used, which is negotiated over stdout.
 type Runner interface {
-	// Start should start the plugin and ensure any work required for servicing
-	// other interface methods is done. If the context is cancelled, it should
-	// only abort any attempts to _start_ the plugin. Waiting and shutdown are
-	// handled separately.
-	Start(ctx context.Context) error
+	// Start should start the plugin and ensure any context required for servicing
+	// other interface methods is set up.
+	Start() error
 
 	// Stdout is used to negotiate the go-plugin protocol.
 	Stdout() io.ReadCloser
@@ -37,10 +34,10 @@ type Runner interface {
 type AttachedRunner interface {
 	// Wait should wait until the plugin stops running, whether in response to
 	// an out of band signal or in response to calling Kill().
-	Wait(ctx context.Context) error
+	Wait() error
 
 	// Kill should stop the plugin and perform any cleanup required.
-	Kill(ctx context.Context) error
+	Kill() error
 
 	// ID is a unique identifier to represent the running plugin. e.g. pid or
 	// container ID.


### PR DESCRIPTION
Reverts hashicorp/go-plugin#273

This changed a public API without an associated bump in the API version, violating go module rules.