### PR TITLE
Changelog++ for v1.5.0 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,29 +2,29 @@
 
 ENHANCEMENTS:
 
-* client: New `runner.Runner` interface to support clients providing custom plugin command runner implementations [GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
+* client: New `runner.Runner` interface to support clients providing custom plugin command runner implementations [[GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
     * Accessible via new `ClientConfig` field `RunnerFunc`, which is mutually exclusive with `Cmd` and `Reattach`
     * Reattaching support via `ReattachConfig` field `ReattachFunc`
-* client: New `ClientConfig` field `SkipHostEnv` allows omitting the client process' own environment variables from the plugin command's environment [GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
-* client: Add `ID()` method to `Client` for retrieving the pid or other unique ID of a running plugin [GH-272](https://github.com/hashicorp/go-plugin/pull/272)]
-* server: Support setting the directory to create Unix sockets in with the env var `PLUGIN_UNIX_SOCKET_DIR` [GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
-* server: Support setting group write permission and a custom group name or gid owner with the env var `PLUGIN_UNIX_SOCKET_GROUP` [GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
+* client: New `ClientConfig` field `SkipHostEnv` allows omitting the client process' own environment variables from the plugin command's environment [[GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
+* client: Add `ID()` method to `Client` for retrieving the pid or other unique ID of a running plugin [[GH-272](https://github.com/hashicorp/go-plugin/pull/272)]
+* server: Support setting the directory to create Unix sockets in with the env var `PLUGIN_UNIX_SOCKET_DIR` [[GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
+* server: Support setting group write permission and a custom group name or gid owner with the env var `PLUGIN_UNIX_SOCKET_GROUP` [[GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
 
 ## v1.4.11-rc1
 
 ENHANCEMENTS:
 
-* deps: bump protoreflect to v1.15.1 [GH-264](https://github.com/hashicorp/go-plugin/pull/264)]
+* deps: bump protoreflect to v1.15.1 [[GH-264](https://github.com/hashicorp/go-plugin/pull/264)]
 
 ## v1.4.10
 
 BUG FIXES:
 
-* additional notes: ensure to close files [GH-241](https://github.com/hashicorp/go-plugin/pull/241)]
+* additional notes: ensure to close files [[GH-241](https://github.com/hashicorp/go-plugin/pull/241)]
 
 ENHANCEMENTS:
 
-* deps: Remove direct dependency on golang.org/x/net [GH-240](https://github.com/hashicorp/go-plugin/pull/240)]
+* deps: Remove direct dependency on golang.org/x/net [[GH-240](https://github.com/hashicorp/go-plugin/pull/240)]
 
 ## v1.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v1.5.0
+
+ENHANCEMENTS:
+
+* client: New `runner.Runner` interface to support clients providing custom plugin command runner implementations [GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
+    * Accessible via new `ClientConfig` field `RunnerFunc`, which is mutually exclusive with `Cmd` and `Reattach`
+    * Reattaching support via `ReattachConfig` field `ReattachFunc`
+* client: New `ClientConfig` field `SkipHostEnv` allows omitting the client process' own environment variables from the plugin command's environment [GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
+* client: Add `ID()` method to `Client` for retrieving the pid or other unique ID of a running plugin [GH-272](https://github.com/hashicorp/go-plugin/pull/272)]
+* server: Support setting the directory to create Unix sockets in with the env var `PLUGIN_UNIX_SOCKET_DIR` [GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
+* server: Support setting group write permission and a custom group name or gid owner with the env var `PLUGIN_UNIX_SOCKET_GROUP` [GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
+
 ## v1.4.11-rc1
 
 ENHANCEMENTS:

--- a/internal/cmdrunner/cmd_runner.go
+++ b/internal/cmdrunner/cmd_runner.go
@@ -30,7 +30,7 @@ const unrecognizedRemotePluginMessage = `This usually means
   the plugin failed to negotiate the initial go-plugin protocol handshake
 %s`
 
-// CmdRunner implements the Executor interface. It mostly just passes through
+// CmdRunner implements the runner.Runner interface. It mostly just passes through
 // to exec.Cmd methods.
 type CmdRunner struct {
 	logger hclog.Logger


### PR DESCRIPTION
Full diff: https://github.com/hashicorp/go-plugin/compare/v1.4.11-rc1...f73a4982b4e3f499c0cd629998b9243f841822c3?expand=1

## v1.5.0

### Enhancements

* client: New `runner.Runner` interface to support clients providing custom plugin command runner implementations [[GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
    * Accessible via new `ClientConfig` field `RunnerFunc`, which is mutually exclusive with `Cmd` and `Reattach`
    * Reattaching support via `ReattachConfig` field `ReattachFunc`
* client: New `ClientConfig` field `SkipHostEnv` allows omitting the client process' own environment variables from the plugin command's environment [[GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
* client: Add `ID()` method to `Client` for retrieving the pid or other unique ID of a running plugin [[GH-272](https://github.com/hashicorp/go-plugin/pull/272)]
* server: Support setting the directory to create Unix sockets in with the env var `PLUGIN_UNIX_SOCKET_DIR` [[GH-270](https://github.com/hashicorp/go-plugin/pull/270)]
* server: Support setting group write permission and a custom group name or gid owner with the env var `PLUGIN_UNIX_SOCKET_GROUP` [[GH-270](https://github.com/hashicorp/go-plugin/pull/270)]