### PR TITLE
Add TempDir option to UnixSocketConfig

### DIFF
--- a/client.go
+++ b/client.go
@@ -252,16 +252,14 @@ type UnixSocketConfig struct {
 	// client process must be a member of this group or chown will fail.
 	Group string
 
+	// TempDir specifies the base directory to use when creating a plugin-specific
+	// temporary directory. It is expected to already exist and be writable. If
+	// not set, defaults to the directory chosen by os.MkdirTemp.
+	TempDir string
+
 	// The directory to create Unix sockets in. Internally managed by go-plugin
 	// and deleted when the plugin is killed.
 	directory string
-}
-
-func unixSocketConfigFromEnv() UnixSocketConfig {
-	return UnixSocketConfig{
-		Group:     os.Getenv(EnvUnixSocketGroup),
-		directory: os.Getenv(EnvUnixSocketDir),
-	}
 }
 
 // ReattachConfig is used to configure a client to reattach to an
@@ -662,7 +660,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	var runner runner.Runner
 	switch {
 	case c.config.RunnerFunc != nil:
-		c.unixSocketCfg.directory, err = os.MkdirTemp("", "plugin-dir")
+		c.unixSocketCfg.directory, err = os.MkdirTemp(c.unixSocketCfg.TempDir, "plugin-dir")
 		if err != nil {
 			return nil, err
 		}

--- a/client.go
+++ b/client.go
@@ -650,7 +650,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	}
 
 	if c.config.UnixSocketConfig != nil {
-		c.unixSocketCfg.Group = c.config.UnixSocketConfig.Group
+		c.unixSocketCfg = *c.config.UnixSocketConfig
 	}
 
 	if c.unixSocketCfg.Group != "" {

--- a/constants.go
+++ b/constants.go
@@ -4,6 +4,11 @@
 package plugin
 
 const (
-	EnvUnixSocketDir   = "PLUGIN_UNIX_SOCKET_DIR"
+	// EnvUnixSocketDir specifies the directory that _plugins_ should create unix
+	// sockets in. Does not affect client behavior.
+	EnvUnixSocketDir = "PLUGIN_UNIX_SOCKET_DIR"
+
+	// EnvUnixSocketGroup specifies the owning, writable group to set for Unix
+	// sockets created by _plugins_. Does not affect client behavior.
 	EnvUnixSocketGroup = "PLUGIN_UNIX_SOCKET_GROUP"
 )

--- a/server.go
+++ b/server.go
@@ -134,6 +134,13 @@ type ServeTestConfig struct {
 	SyncStdio bool
 }
 
+func unixSocketConfigFromEnv() UnixSocketConfig {
+	return UnixSocketConfig{
+		Group:     os.Getenv(EnvUnixSocketGroup),
+		directory: os.Getenv(EnvUnixSocketDir),
+	}
+}
+
 // protocolVersion determines the protocol version and plugin set to be used by
 // the server. In the event that there is no suitable version, the last version
 // in the config is returned leaving the client to report the incompatibility.

--- a/server.go
+++ b/server.go
@@ -137,7 +137,7 @@ type ServeTestConfig struct {
 func unixSocketConfigFromEnv() UnixSocketConfig {
 	return UnixSocketConfig{
 		Group:     os.Getenv(EnvUnixSocketGroup),
-		directory: os.Getenv(EnvUnixSocketDir),
+		socketDir: os.Getenv(EnvUnixSocketDir),
 	}
 }
 
@@ -554,7 +554,7 @@ func serverListener_tcp() (net.Listener, error) {
 }
 
 func serverListener_unix(unixSocketCfg UnixSocketConfig) (net.Listener, error) {
-	tf, err := os.CreateTemp(unixSocketCfg.directory, "plugin")
+	tf, err := os.CreateTemp(unixSocketCfg.socketDir, "plugin")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When running plugins in containers with systemd's [PrivateTmp=true](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#PrivateTmp=) setting, the containers are not sub-processes so they are not part of the plugin client's file system namespace - as such `/tmp` is different for the 2 sides of the connection and they can't establish communication.

As a workaround, TMPDIR can be set to something that _is_ the same on both sides like `/home/user/tmp`, but that punctures the PrivateTmp setting for all other uses of `/tmp` as well. This lets us choose a single exception.