### PR TITLE
logging: lower priority of configuring messages

### DIFF
--- a/client.go
+++ b/client.go
@@ -670,7 +670,7 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	// Setup a temporary certificate for client/server mtls, and send the public
 	// certificate to the plugin.
 	if c.config.AutoMTLS {
-		c.logger.Info("configuring client automatic mTLS")
+		c.logger.Debug("configuring client automatic mTLS")
 		certPEM, keyPEM, err := generateCert()
 		if err != nil {
 			c.logger.Error("failed to generate client certificate", "error", err)

--- a/server.go
+++ b/server.go
@@ -307,7 +307,7 @@ func Serve(opts *ServeConfig) {
 	// If the client is configured using AutoMTLS, the certificate will be here,
 	// and we need to generate our own in response.
 	if tlsConfig == nil && clientCert != "" {
-		logger.Info("configuring server automatic mTLS")
+		logger.Debug("configuring server automatic mTLS")
 		clientCertPool := x509.NewCertPool()
 		if !clientCertPool.AppendCertsFromPEM([]byte(clientCert)) {
 			logger.Error("client cert provided but failed to parse", "cert", clientCert)


### PR DESCRIPTION
When using terraform with many providers and all of them print these
messages for no value at all.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
