### PR TITLE
New client option `DisableLogStderr` to disable expensive log stderr from subprocess

### DIFF
--- a/client.go
+++ b/client.go
@@ -199,6 +199,11 @@ type ClientConfig struct {
 	// This isn't the output of synced stderr.
 	Stderr io.Writer
 
+	// DisableLogStderr discards anything streamed from os.Stderr of the subprocess.
+	// This won't impact the synced stderr though.
+	// The main purpose is to reduce performance consumption when working with a wordy provider.
+	DisableLogStderr bool
+
 	// SyncStdout, SyncStderr can be set to override the
 	// respective os.Std* values in the plugin. Care should be taken to
 	// avoid races here. If these are nil, then this will be set to
@@ -1176,6 +1181,10 @@ func (c *Client) logStderr(name string, r io.Reader) {
 		case err != nil:
 			l.Error("reading plugin stderr", "error", err)
 			return
+		}
+
+		if c.config.DisableLogStderr {
+			continue
 		}
 
 		c.config.Stderr.Write(line)


### PR DESCRIPTION
I have a light weighted [go-plugin client](https://github.com/magodo/terraform-client-go) that talks to a terraform provider, mainly to [import and read one or more terraform resources](https://github.com/magodo/terraform-client-go/tree/main/cmd/terraform-client-import) from the provider.

I expect this is anI/O bound task, instead of CPU intensive, as the client&provider will be waiting for the cloud platform API call in most of the time. However, the result turns out the CPU is also non-negligible.

The provider I'm talking to is the `terraform-provider-azurerm`, whose on initialization is a bit wordy that will print a bunch of logs. By doing [some benchmark and profiling](https://github.com/magodo/terraform-client-go/blob/3f3dd98aaf22733412a12ef101766562edd2fc1e/tfclient/tfclient_test.go#L60-L70). I noticed that the go routine for logging stderr from the subprocess is consuming about 20% of the CPU time:

![image](https://github.com/user-attachments/assets/1d79d923-38d8-436b-9531-237db1608edd)

With this PR to disable the log stderr, especially the expensive `parseJSON`, we can get 20% performance improvement:

![image](https://github.com/user-attachments/assets/0b6c3e6f-10d4-4bea-bc0e-3f731de6a8bd)

Ideally, we shall check whether the `logger` is a `hclog.NullLogger` and the `config.Stderr` is `io.Discard`, instead of introducing this new property. While I don't know if there is a way to do the first check (as the current default behaivor for null `config.Logger` is to set a logger to set a non-noop logger.

Also note that when this `DisableLogStderr` won't  stop spawning the go routine at all since we still need to check whether the stderr hit EOF to tell whether the subprocess has ended.