### PR TITLE
Modify go_package to a full path in plugin's proto

### DIFF
--- a/internal/plugin/grpc_broker.proto
+++ b/internal/plugin/grpc_broker.proto
@@ -3,7 +3,7 @@
 
 syntax = "proto3";
 package plugin;
-option go_package = "./plugin";
+option go_package = "github.com/hashicorp/go-plugin/internal/plugin";
 
 message ConnInfo {
     uint32 service_id = 1;

--- a/internal/plugin/grpc_controller.proto
+++ b/internal/plugin/grpc_controller.proto
@@ -3,7 +3,7 @@
 
 syntax = "proto3";
 package plugin;
-option go_package = "./plugin";
+option go_package = "github.com/hashicorp/go-plugin/internal/plugin";
 
 message Empty {
 }

--- a/internal/plugin/grpc_stdio.proto
+++ b/internal/plugin/grpc_stdio.proto
@@ -3,7 +3,7 @@
 
 syntax = "proto3";
 package plugin;
-option go_package = "./plugin";
+option go_package = "github.com/hashicorp/go-plugin/internal/plugin";
 
 import "google/protobuf/empty.proto";
 


### PR DESCRIPTION
These changes is friendly for bazel to avoid from the error “missing strict dependencies” .

When I used bazel build to build exe file, I encountered the error：
compilepkg: missing strict dependencies:
        /private/var/tmp/_bazel_kk/43cdc04641453be2515122d57e93f7eb/sandbox/darwin-sandbox/1312/execroot/_main/external/gazelle~~go_deps~com_github_hashicorp_go_plugin/grpc_broker.go: import of "github.com/hashicorp/go-plugin/internal/plugin"
        /private/var/tmp/_bazel_kk/43cdc04641453be2515122d57e93f7eb/sandbox/darwin-sandbox/1312/execroot/_main/external/gazelle~~go_deps~com_github_hashicorp_go_plugin/grpc_client.go: import of "github.com/hashicorp/go-plugin/internal/plugin"
        /private/var/tmp/_bazel_kk/43cdc04641453be2515122d57e93f7eb/sandbox/darwin-sandbox/1312/execroot/_main/external/gazelle~~go_deps~com_github_hashicorp_go_plugin/grpc_controller.go: import of "github.com/hashicorp/go-plugin/internal/plugin"
        /private/var/tmp/_bazel_kk/43cdc04641453be2515122d57e93f7eb/sandbox/darwin-sandbox/1312/execroot/_main/external/gazelle~~go_deps~com_github_hashicorp_go_plugin/grpc_server.go: import of "github.com/hashicorp/go-plugin/internal/plugin"
        /private/var/tmp/_bazel_kk/43cdc04641453be2515122d57e93f7eb/sandbox/darwin-sandbox/1312/execroot/_main/external/gazelle~~go_deps~com_github_hashicorp_go_plugin/grpc_stdio.go: import of "github.com/hashicorp/go-plugin/internal/plugin"
No dependencies were provided.

The reason is that the go_package be set to relative path, and bazel can not identify it.

Though these maybe are the issues of  bazel,  using full path in golang is common too. So I pull this request.