### PR TITLE
Don't add magic cookie to env if unspecified

### DIFF
--- a/client.go
+++ b/client.go
@@ -637,10 +637,12 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	}
 
 	env := []string{
-		fmt.Sprintf("%s=%s", c.config.MagicCookieKey, c.config.MagicCookieValue),
 		fmt.Sprintf("PLUGIN_MIN_PORT=%d", c.config.MinPort),
 		fmt.Sprintf("PLUGIN_MAX_PORT=%d", c.config.MaxPort),
 		fmt.Sprintf("PLUGIN_PROTOCOL_VERSIONS=%s", strings.Join(versionStrings, ",")),
+	}
+	if len(c.config.MagicCookieKey) > 0 {
+		env = append(env, fmt.Sprintf("%s=%s", c.config.MagicCookieKey, c.config.MagicCookieValue))
 	}
 	if c.config.GRPCBrokerMultiplex {
 		env = append(env, fmt.Sprintf("%s=true", envMultiplexGRPC))


### PR DESCRIPTION
On Windows, I found that not setting the `MagicCookieKey` resulted in the error. When set to any non-zero value, the plugin executed as expected. Windows does not like the empty `=` parameter passed to the command's `Env` parameter.

```
fork/exec foobar.exe: The parameter is incorrect.
```