### PR TITLE
refactor(protobuf): update protobuf imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/hashicorp/go-plugin
 go 1.24
 
 require (
-	github.com/golang/protobuf v1.5.3
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/yamux v0.1.1
 	github.com/jhump/protoreflect v1.15.1
@@ -15,6 +14,7 @@ require (
 require (
 	github.com/bufbuild/protocompile v0.4.0 // indirect
 	github.com/fatih/color v1.7.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/stretchr/testify v1.8.3 // indirect

--- a/grpc_stdio.go
+++ b/grpc_stdio.go
@@ -9,12 +9,12 @@ import (
 	"context"
 	"io"
 
-	empty "github.com/golang/protobuf/ptypes/empty"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin/internal/plugin"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	empty "google.golang.org/protobuf/types/known/emptypb"
 )
 
 // grpcStdioBuffer is the buffer size we try to fill when sending a chunk of

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -18,10 +18,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/go-hclog"
 	grpctest "github.com/hashicorp/go-plugin/test/grpc"
 	"google.golang.org/grpc"
+	empty "google.golang.org/protobuf/types/known/emptypb"
 )
 
 // Test that NetRPCUnsupportedPlugin implements the correct interfaces.


### PR DESCRIPTION
## Summary
Following [this issue](https://github.com/golang/protobuf/issues/1417), update deprecated protobuf imports to `google.golang.org/protobuf`.
Closes #338 (confirmed that the test passed in 1.24.0)