### PR TITLE
fix errcheck lint errors and run it as part of pr checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,10 @@ jobs:
           echo "$files"
           exit 1
         fi
+    - name: Lint code
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+      with:
+        args: --enable-only errcheck # this is temporary until the other lint errors are fixed
   go-test:
     needs: go-fmt-and-vet
     runs-on: ubuntu-latest

--- a/client_posix_test.go
+++ b/client_posix_test.go
@@ -47,7 +47,7 @@ func TestClient_testInterfaceReattach(t *testing.T) {
 		c.Kill()
 		t.Fatalf("couldn't find process: %s", err)
 	}
-	defer p.Kill()
+	defer func() { _ = p.Kill() }()
 
 	// Reattach
 	c = NewClient(&ClientConfig{

--- a/client_test.go
+++ b/client_test.go
@@ -72,7 +72,7 @@ func TestClient(t *testing.T) {
 func TestClient_killStart(t *testing.T) {
 	// Create a temporary dir to store the result file
 	td := t.TempDir()
-	defer os.RemoveAll(td)
+	defer func() { _ = os.RemoveAll(td) }()
 
 	// Start the client
 	path := filepath.Join(td, "booted")
@@ -281,7 +281,7 @@ func TestClient_grpc_servercrash(t *testing.T) {
 		t.Fatalf("bad: %#v", raw)
 	}
 
-	c.runner.Kill(context.Background())
+	_ = c.runner.Kill(context.Background())
 
 	select {
 	case <-c.doneCtx.Done():
@@ -682,7 +682,7 @@ func TestClient_reattachNotFound(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	addr := l.Addr()
-	l.Close()
+	_ = l.Close()
 
 	// Reattach
 	c := NewClient(&ClientConfig{
@@ -884,8 +884,8 @@ func TestClient_Stdin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	defer os.Remove(tf.Name())
-	defer tf.Close()
+	defer func() { _ = os.Remove(tf.Name()) }()
+	defer func() { _ = tf.Close() }()
 
 	if _, err = tf.WriteString("hello"); err != nil {
 		t.Fatalf("error: %s", err)
@@ -1023,7 +1023,7 @@ func TestClient_SecureConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	hash := sha256.New()
 
@@ -1338,7 +1338,7 @@ func TestClient_versionedClient(t *testing.T) {
 		t.Fatalf("bad: %#v", raw)
 	}
 
-	c.runner.Kill(context.Background())
+	_ = c.runner.Kill(context.Background())
 
 	select {
 	case <-c.doneCtx.Done():
@@ -1394,7 +1394,7 @@ func TestClient_mtlsClient(t *testing.T) {
 		t.Fatal("invalid response", n)
 	}
 
-	c.runner.Kill(context.Background())
+	_ = c.runner.Kill(context.Background())
 
 	select {
 	case <-c.doneCtx.Done():
@@ -1440,7 +1440,7 @@ func TestClient_mtlsNetRPCClient(t *testing.T) {
 		t.Fatal("invalid response", n)
 	}
 
-	c.runner.Kill(context.Background())
+	_ = c.runner.Kill(context.Background())
 
 	select {
 	case <-c.doneCtx.Done():

--- a/examples/bidirectional/shared/grpc.go
+++ b/examples/bidirectional/shared/grpc.go
@@ -66,7 +66,7 @@ func (m *GRPCServer) Put(ctx context.Context, req *proto.PutRequest) (*proto.Emp
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	a := &GRPCAddHelperClient{proto.NewAddHelperClient(conn)}
 	return &proto.Empty{}, m.Impl.Put(req.Key, req.Value, a)

--- a/grpc_broker.go
+++ b/grpc_broker.go
@@ -382,7 +382,7 @@ func (b *GRPCBroker) AcceptAndServe(id uint32, newGRPCServer func([]grpc.ServerO
 		log.Printf("[ERR] plugin: plugin acceptAndServe error: %s", err)
 		return
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	var opts []grpc.ServerOption
 	if b.tls != nil {
@@ -418,7 +418,7 @@ func (b *GRPCBroker) AcceptAndServe(id uint32, newGRPCServer func([]grpc.ServerO
 	}
 
 	// Block until we are done
-	g.Run()
+	_ = g.Run()
 }
 
 // Close closes the stream and all servers.

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -70,7 +70,7 @@ func newGRPCClient(doneCtx context.Context, c *Client) (*GRPCClient, error) {
 	brokerGRPCClient := newGRPCBrokerClient(conn)
 	broker := newGRPCBroker(brokerGRPCClient, c.config.TLSConfig, c.unixSocketCfg, c.runner, muxer)
 	go broker.Run()
-	go brokerGRPCClient.StartStream()
+	go func() { _ = brokerGRPCClient.StartStream() }()
 
 	// Start the stdio client
 	stdioClient, err := newGRPCStdioClient(doneCtx, c.logger.Named("stdio"), conn)
@@ -103,8 +103,8 @@ type GRPCClient struct {
 
 // ClientProtocol impl.
 func (c *GRPCClient) Close() error {
-	c.broker.Close()
-	c.controller.Shutdown(c.doneCtx, &plugin.Empty{})
+	_ = c.broker.Close()
+	_, _ = c.controller.Shutdown(c.doneCtx, &plugin.Empty{})
 	return c.Conn.Close()
 }
 

--- a/grpc_client_test.go
+++ b/grpc_client_test.go
@@ -27,7 +27,7 @@ func testGRPCClientApp(t *testing.T, multiplex bool) {
 	client, server := TestPluginGRPCConn(t, multiplex, map[string]Plugin{
 		"test": new(testGRPCInterfacePlugin),
 	})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	defer server.Stop()
 
 	raw, err := client.Dispense("test")
@@ -55,7 +55,7 @@ func TestGRPCConn_BidirectionalPing(t *testing.T) {
 	conn, _ := TestGRPCConn(t, func(s *grpc.Server) {
 		grpctest.RegisterPingPongServer(s, &pingPongServer{})
 	})
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	pingPongClient := grpctest.NewPingPongClient(conn)
 
 	pResp, err := pingPongClient.Ping(context.Background(), &grpctest.PingRequest{})
@@ -80,7 +80,7 @@ func testGRPCStream(t *testing.T, multiplex bool) {
 	client, server := TestPluginGRPCConn(t, multiplex, map[string]Plugin{
 		"test": new(testGRPCInterfacePlugin),
 	})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	defer server.Stop()
 
 	raw, err := client.Dispense("test")
@@ -117,7 +117,7 @@ func testGRPCClientPing(t *testing.T, multiplex bool) {
 	client, server := TestPluginGRPCConn(t, multiplex, map[string]Plugin{
 		"test": new(testGRPCInterfacePlugin),
 	})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	defer server.Stop()
 
 	// Run a couple pings
@@ -152,7 +152,7 @@ func testGRPCClientReflection(t *testing.T, multiplex bool) {
 	client, server := TestPluginGRPCConn(t, multiplex, map[string]Plugin{
 		"test": new(testGRPCInterfacePlugin),
 	})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	defer server.Stop()
 
 	refClient := grpcreflect.NewClient(ctx, reflectpb.NewServerReflectionClient(client.Conn))

--- a/grpc_server.go
+++ b/grpc_server.go
@@ -119,7 +119,7 @@ func (s *GRPCServer) Stop() {
 	s.server.Stop()
 
 	if s.broker != nil {
-		s.broker.Close()
+		_ = s.broker.Close()
 		s.broker = nil
 	}
 }
@@ -130,7 +130,7 @@ func (s *GRPCServer) GracefulStop() {
 	s.server.GracefulStop()
 
 	if s.broker != nil {
-		s.broker.Close()
+		_ = s.broker.Close()
 		s.broker = nil
 	}
 }

--- a/internal/cmdrunner/cmd_reattach.go
+++ b/internal/cmdrunner/cmd_reattach.go
@@ -30,7 +30,7 @@ func ReattachFunc(pid int, addr net.Addr) runner.ReattachFunc {
 		if err != nil {
 			return nil, ErrProcessNotFound
 		}
-		conn.Close()
+		_ = conn.Close()
 
 		return &CmdAttachedRunner{
 			pid:     pid,

--- a/internal/cmdrunner/notes_unix.go
+++ b/internal/cmdrunner/notes_unix.go
@@ -53,13 +53,13 @@ func additionalNotesAboutCommand(path string) string {
 	}
 
 	if elfFile, err := elf.Open(path); err == nil {
-		defer elfFile.Close()
+		defer func() { _ = elfFile.Close() }()
 		notes += fmt.Sprintf("  ELF architecture: %s (current architecture: %s)\n", elfFile.Machine, runtime.GOARCH)
 	} else if machoFile, err := macho.Open(path); err == nil {
-		defer machoFile.Close()
+		defer func() { _ = machoFile.Close() }()
 		notes += fmt.Sprintf("  MachO architecture: %s (current architecture: %s)\n", machoFile.Cpu, runtime.GOARCH)
 	} else if peFile, err := pe.Open(path); err == nil {
-		defer peFile.Close()
+		defer func() { _ = peFile.Close() }()
 		machine, ok := peTypes[peFile.Machine]
 		if !ok {
 			machine = "unknown"

--- a/mux_broker.go
+++ b/mux_broker.go
@@ -68,7 +68,7 @@ func (m *MuxBroker) Accept(id uint32) (net.Conn, error) {
 
 	// Ack our connection
 	if err := binary.Write(c, binary.LittleEndian, id); err != nil {
-		c.Close()
+		_ = c.Close()
 		return nil, err
 	}
 
@@ -105,18 +105,18 @@ func (m *MuxBroker) Dial(id uint32) (net.Conn, error) {
 
 	// Write the stream ID onto the wire.
 	if err := binary.Write(stream, binary.LittleEndian, id); err != nil {
-		stream.Close()
+		_ = stream.Close()
 		return nil, err
 	}
 
 	// Read the ack that we connected. Then we're off!
 	var ack uint32
 	if err := binary.Read(stream, binary.LittleEndian, &ack); err != nil {
-		stream.Close()
+		_ = stream.Close()
 		return nil, err
 	}
 	if ack != id {
-		stream.Close()
+		_ = stream.Close()
 		return nil, fmt.Errorf("bad ack: %d (expected %d)", ack, id)
 	}
 
@@ -148,7 +148,7 @@ func (m *MuxBroker) Run() {
 		// Read the stream ID from the stream
 		var id uint32
 		if err := binary.Read(stream, binary.LittleEndian, &id); err != nil {
-			stream.Close()
+			_ = stream.Close()
 			continue
 		}
 
@@ -201,7 +201,7 @@ func (m *MuxBroker) timeoutWait(id uint32, p *muxBrokerPending) {
 	if timeout {
 		select {
 		case s := <-p.ch:
-			s.Close()
+			_ = s.Close()
 		}
 	}
 }

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -141,13 +141,13 @@ func (i *testInterfaceImpl) Bidirectional() error {
 
 func (i *testInterfaceImpl) PrintStdio(stdout, stderr []byte) {
 	if len(stdout) > 0 {
-		fmt.Fprint(os.Stdout, string(stdout))
-		os.Stdout.Sync()
+		_, _ = fmt.Fprint(os.Stdout, string(stdout))
+		_ = os.Stdout.Sync()
 	}
 
 	if len(stderr) > 0 {
-		fmt.Fprint(os.Stderr, string(stderr))
-		os.Stderr.Sync()
+		_, _ = fmt.Fprint(os.Stderr, string(stderr))
+		_ = os.Stderr.Sync()
 	}
 }
 
@@ -405,7 +405,7 @@ func (impl *testGRPCClient) Stream(start, stop int32) ([]int32, error) {
 		resp = append(resp, out.Output)
 	}
 
-	streamClient.CloseSend()
+	_ = streamClient.CloseSend()
 
 	return resp, nil
 }
@@ -500,20 +500,20 @@ func TestHelperProcess(*testing.T) {
 		os.Exit(1)
 	case "stderr":
 		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
-		os.Stderr.WriteString("HELLO\n")
-		os.Stderr.WriteString("WORLD\n")
+		_, _ = os.Stderr.WriteString("HELLO\n")
+		_, _ = os.Stderr.WriteString("WORLD\n")
 	case "stderr-json":
 		// write values that might be JSON, but aren't KVs
-		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
-		os.Stderr.WriteString("[\"HELLO\"]\n")
-		os.Stderr.WriteString("12345\n")
-		os.Stderr.WriteString("{\"a\":1}\n")
+		_, _ = fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
+		_, _ = os.Stderr.WriteString("[\"HELLO\"]\n")
+		_, _ = os.Stderr.WriteString("12345\n")
+		_, _ = os.Stderr.WriteString("{\"a\":1}\n")
 	case "level-warn-text":
 		// write values that might be JSON, but aren't KVs
-		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
-		os.Stderr.WriteString("[WARN] test line 98765\n")
+		_, _ = fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
+		_, _ = os.Stderr.WriteString("[WARN] test line 98765\n")
 	case "stdin":
-		fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
+		_, _ = fmt.Printf("%d|%d|tcp|:1234\n", CoreProtocolVersion, testHandshake.ProtocolVersion)
 		data := make([]byte, 5)
 		if _, err := os.Stdin.Read(data); err != nil {
 			log.Printf("stdin read error: %s", err)

--- a/rpc_client.go
+++ b/rpc_client.go
@@ -33,7 +33,7 @@ func newRPCClient(c *Client) (*RPCClient, error) {
 	}
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		// Make sure to set keep alive so that the connection doesn't die
-		tcpConn.SetKeepAlive(true)
+		_ = tcpConn.SetKeepAlive(true)
 	}
 
 	if c.config.TLSConfig != nil {
@@ -43,7 +43,7 @@ func newRPCClient(c *Client) (*RPCClient, error) {
 	// Create the actual RPC client
 	result, err := NewRPCClient(conn, c.config.Plugins)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 
@@ -52,7 +52,7 @@ func newRPCClient(c *Client) (*RPCClient, error) {
 		c.config.SyncStdout,
 		c.config.SyncStderr)
 	if err != nil {
-		result.Close()
+		_ = result.Close()
 		return nil, err
 	}
 
@@ -65,14 +65,14 @@ func NewRPCClient(conn io.ReadWriteCloser, plugins map[string]Plugin) (*RPCClien
 	// Create the yamux client so we can multiplex
 	mux, err := yamux.Client(conn, nil)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 
 	// Connect to the control stream.
 	control, err := mux.Open()
 	if err != nil {
-		mux.Close()
+		_ = mux.Close()
 		return nil, err
 	}
 
@@ -81,7 +81,7 @@ func NewRPCClient(conn io.ReadWriteCloser, plugins map[string]Plugin) (*RPCClien
 	for i, _ := range stdstream {
 		stdstream[i], err = mux.Open()
 		if err != nil {
-			mux.Close()
+			_ = mux.Close()
 			return nil, err
 		}
 	}

--- a/rpc_server.go
+++ b/rpc_server.go
@@ -69,7 +69,7 @@ func (s *RPCServer) ServeConn(conn io.ReadWriteCloser) {
 	// First create the yamux server to wrap this connection
 	mux, err := yamux.Server(conn, nil)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		log.Printf("[ERR] plugin: error creating yamux server: %s", err)
 		return
 	}
@@ -77,7 +77,7 @@ func (s *RPCServer) ServeConn(conn io.ReadWriteCloser) {
 	// Accept the control connection
 	control, err := mux.Accept()
 	if err != nil {
-		mux.Close()
+		_ = mux.Close()
 		if err != io.EOF {
 			log.Printf("[ERR] plugin: error accepting control connection: %s", err)
 		}
@@ -90,7 +90,7 @@ func (s *RPCServer) ServeConn(conn io.ReadWriteCloser) {
 	for i := range stdstream {
 		stdstream[i], err = mux.Accept()
 		if err != nil {
-			mux.Close()
+			_ = mux.Close()
 			log.Printf("[ERR] plugin: accepting stream %d: %s", i, err)
 			return
 		}
@@ -107,10 +107,10 @@ func (s *RPCServer) ServeConn(conn io.ReadWriteCloser) {
 	// Use the control connection to build the dispenser and serve the
 	// connection.
 	server := rpc.NewServer()
-	server.RegisterName("Control", &controlServer{
+	_ = server.RegisterName("Control", &controlServer{
 		server: s,
 	})
-	server.RegisterName("Dispenser", &dispenseServer{
+	_ = server.RegisterName("Dispenser", &dispenseServer{
 		broker:  broker,
 		plugins: s.Plugins,
 	})

--- a/server.go
+++ b/server.go
@@ -290,7 +290,7 @@ func Serve(opts *ServeConfig) {
 	// Close the listener on return. We wrap this in a func() on purpose
 	// because the "listener" reference may change to TLS.
 	defer func() {
-		listener.Close()
+		_ = listener.Close()
 	}()
 
 	var tlsConfig *tls.Config
@@ -443,7 +443,7 @@ func Serve(opts *ServeConfig) {
 			protocolLine += fmt.Sprintf("|%v", grpcBrokerMultiplexingSupported)
 		}
 		fmt.Printf("%s\n", protocolLine)
-		os.Stdout.Sync()
+		_ = os.Stdout.Sync()
 	} else if ch := opts.Test.ReattachConfigCh; ch != nil {
 		// Send back the reattach config that can be used. This isn't
 		// quite ready if they connect immediately but the client should
@@ -505,7 +505,7 @@ func Serve(opts *ServeConfig) {
 		// Cancellation. We can stop the server by closing the listener.
 		// This isn't graceful at all but this is currently only used by
 		// tests and its our only way to stop.
-		listener.Close()
+		_ = listener.Close()
 
 		// If this is a grpc server, then we also ask the server itself to
 		// end which will kill all connections. There isn't an easy way to do

--- a/server_unix_test.go
+++ b/server_unix_test.go
@@ -35,7 +35,7 @@ func TestUnixSocketGroupPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer ln.Close()
+			defer func() { _ = ln.Close() }()
 
 			info, err := os.Lstat(ln.Addr().String())
 			if err != nil {


### PR DESCRIPTION
Unhandled errors are now swallowed by assignment to `_`.