### PR TITLE
Spend less time preparing to write log lines when the logger is disabled

### DIFF
--- a/client.go
+++ b/client.go
@@ -1167,7 +1167,10 @@ func (c *Client) getGRPCMuxer(addr net.Addr) (*grpcmux.GRPCClientMuxer, error) {
 func (c *Client) logStderr(name string, r io.Reader) {
 	defer c.clientWaitGroup.Done()
 	defer c.pipesWaitGroup.Done()
+
 	l := c.logger.Named(filepath.Base(name))
+	loggerLevel := l.GetLevel()
+	loggerDisabled := loggerLevel == hclog.Off
 
 	reader := bufio.NewReaderSize(r, c.config.PluginLogBufferSize)
 	// continuation indicates the previous line was a prefix
@@ -1203,6 +1206,18 @@ func (c *Client) logStderr(name string, r io.Reader) {
 
 		_, _ = c.config.Stderr.Write([]byte{'\n'})
 
+		//
+		// Any side-effects other than writing to the hclog logger must be
+		// above this point!
+		//
+
+		if loggerDisabled {
+			// If the logger we'd be writing to is completely disabled then
+			// we can skip all of the parsing work to decide what log level
+			// we'd use to write this line.
+			continue
+		}
+
 		entry, err := parseJSON(line)
 		// If output is not JSON format, print directly to Debug
 		if err != nil {
@@ -1236,10 +1251,17 @@ func (c *Client) logStderr(name string, r io.Reader) {
 			}
 		} else {
 			panic = false
-			out := flattenKVPairs(entry.KVPairs)
 
+			logLevel := hclog.LevelFromString(entry.Level)
+			if logLevel < loggerLevel {
+				// The logger will ignore this log entry anyway, so we
+				// won't spend any more time preparing it.
+				continue
+			}
+
+			out := flattenKVPairs(entry.KVPairs)
 			out = append(out, "timestamp", entry.Timestamp.Format(hclog.TimeFormat))
-			switch hclog.LevelFromString(entry.Level) {
+			switch logLevel {
 			case hclog.Trace:
 				l.Trace(entry.Message, out...)
 			case hclog.Debug:

--- a/client.go
+++ b/client.go
@@ -1253,7 +1253,7 @@ func (c *Client) logStderr(name string, r io.Reader) {
 			panic = false
 
 			logLevel := hclog.LevelFromString(entry.Level)
-			if logLevel < loggerLevel {
+			if logLevel != hclog.NoLevel && logLevel < loggerLevel {
 				// The logger will ignore this log entry anyway, so we
 				// won't spend any more time preparing it.
 				continue

--- a/client_logger_test.go
+++ b/client_logger_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-func BenchmarkClientLogging_enabled(b *testing.B) {
+func BenchmarkClientLogging(b *testing.B) {
 	// We're not actually going to start the process in this benchmark,
 	// so this is just a placeholder to satisfy the ClientConfig.
 	process := helperProcess("bad-version")
@@ -50,7 +50,10 @@ func BenchmarkClientLogging_enabled(b *testing.B) {
 					b.Fatal("failed to write to pipe")
 				}
 			}
-			w.Close() // causes the c.logStderr goroutine to exit
+			err := w.Close() // causes the c.logStderr goroutine to exit
+			if err != nil {
+				b.Fatalf("failed to close write end of pipe: %s", err)
+			}
 		})
 	}
 }

--- a/client_logger_test.go
+++ b/client_logger_test.go
@@ -1,0 +1,56 @@
+package plugin
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func BenchmarkClientLogging_enabled(b *testing.B) {
+	// We're not actually going to start the process in this benchmark,
+	// so this is just a placeholder to satisfy the ClientConfig.
+	process := helperProcess("bad-version")
+
+	tests := map[string]hclog.Level{
+		"off":   hclog.Off,
+		"error": hclog.Error,
+		"trace": hclog.Trace,
+	}
+
+	for name, logLevel := range tests {
+		b.Run(name, func(b *testing.B) {
+			logger := hclog.New(&hclog.LoggerOptions{
+				Name:   "test-logger",
+				Level:  logLevel,
+				Output: io.Discard,
+				Mutex:  new(sync.Mutex),
+			})
+
+			c := NewClient(&ClientConfig{
+				Cmd:             process,
+				Stderr:          io.Discard,
+				HandshakeConfig: testHandshake,
+				Logger:          logger,
+				Plugins:         testPluginMap,
+			})
+
+			r, w := io.Pipe()
+
+			c.clientWaitGroup.Add(1)
+			c.pipesWaitGroup.Add(1)
+			// logStderr calls Done() on both waitgroups
+			go c.logStderr("test", r)
+
+			fakeLogLine := []byte("{\"@level\":\"debug\",\"@timestamp\":\"2006-01-02T15:04:05.000000Z\",\"@message\":\"hello\",\"extra\":\"hi\",\"numbers\":[1,2,3]}\n")
+			for b.Loop() {
+				n, err := w.Write(fakeLogLine)
+				if err != nil || n != len(fakeLogLine) {
+					b.Fatal("failed to write to pipe")
+				}
+			}
+			w.Close() // causes the c.logStderr goroutine to exit
+		})
+	}
+}

--- a/log_entry.go
+++ b/log_entry.go
@@ -10,10 +10,10 @@ import (
 
 // logEntry is the JSON payload that gets sent to Stderr from the plugin to the host
 type logEntry struct {
-	Message   string        `json:"@message"`
-	Level     string        `json:"@level"`
-	Timestamp time.Time     `json:"timestamp"`
-	KVPairs   []*logEntryKV `json:"kv_pairs"`
+	Message   string       `json:"@message"`
+	Level     string       `json:"@level"`
+	Timestamp time.Time    `json:"timestamp"`
+	KVPairs   []logEntryKV `json:"kv_pairs"`
 }
 
 // logEntryKV is a key value pair within the Output payload
@@ -24,7 +24,7 @@ type logEntryKV struct {
 
 // flattenKVPairs is used to flatten KVPair slice into []interface{}
 // for hclog consumption.
-func flattenKVPairs(kvs []*logEntryKV) []interface{} {
+func flattenKVPairs(kvs []logEntryKV) []interface{} {
 	var result []interface{}
 	for _, kv := range kvs {
 		result = append(result, kv.Key)
@@ -66,7 +66,7 @@ func parseJSON(input []byte) (*logEntry, error) {
 
 	// Parse dynamic KV args from the hclog payload.
 	for k, v := range raw {
-		entry.KVPairs = append(entry.KVPairs, &logEntryKV{
+		entry.KVPairs = append(entry.KVPairs, logEntryKV{
 			Key:   k,
 			Value: v,
 		})


### PR DESCRIPTION
## Description

In callers like HashiCorp Terraform, the plugin logger is completely disabled (`hclog.Off`) by default, but previously go-plugin would nonetheless waste time trying to parse log lines to decide what log level to use when calling into the logger, creating memory allocation garbage and spending time in the JSON parser only to immediately discard the results.

The `hclog.Logger` API exposes information about the log level so that callers can skip doing expensive preparation work unless it will actually be used. This now uses that to totally skip all of the log preparation when the logger is completely disabled, and to skip _some_ of the work if the log line's level is not sufficient to match the logger's level.

Modern Terraform plugins tend to generate quite a lot of log messages and it seems that at least some of them generate it by default even when none of the logging environment variables are set. I'm not sure if that's intentional, but nonetheless this PR reduces the overhead of processing and discarding those unsolicited log lines enough to make a measurable difference for some providers.

The second commit removes a level of indirection in the internal modelling of additional key/value pairs in the JSON logs, so that instead of performing one allocation per JSON property these allocations are amortized by gradually growing the backing array of the slice. This is a far less significant improvement than the first commit, but it's also a pretty easy and non-invasive change that saves at least a few memory allocations per log line.

The benchmark added in the first commit demonstrates both the most happy path of having the logger disabled entirely, and the slightly-less-happy path of having the logger enabled but filtering out certain levels so it does still need to perform JSON parsing to check whether the log line needs to be logged.

```
BenchmarkClientLogging
BenchmarkClientLogging/off
BenchmarkClientLogging/off-16            3234806               362.5 ns/op             1 B/op          1 allocs/op
BenchmarkClientLogging/error
BenchmarkClientLogging/error-16           367056              2915 ns/op            1096 B/op         36 allocs/op
BenchmarkClientLogging/trace
BenchmarkClientLogging/trace-16           230836              4418 ns/op            1617 B/op         48 allocs/op
```

I believe that the "off" case above represents what Terraform's behavior would be in the default case where the `TF_LOG`/etc environment variables are not set. The "error" case represents `TF_LOG=error`, and "trace" represents `TF_LOG=trace`. As far as I know, Terraform currently behaves like this "trace" case regardless of what the environment variables are set to.

## How Has This Been Tested?

Aside from the new benchmark mentioned above, I also ran the existing test suite and it passed without any modifications.
