### PR TITLE
grpc_client: check SERVING status in Ping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/hashicorp/go-plugin
 go 1.24
 
 require (
-	github.com/golang/protobuf v1.5.4
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/yamux v0.1.2
 	github.com/jhump/protoreflect v1.17.0
@@ -15,6 +14,7 @@ require (
 require (
 	github.com/bufbuild/protocompile v0.14.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	golang.org/x/net v0.38.0 // indirect

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -126,9 +126,16 @@ func (c *GRPCClient) Dispense(name string) (interface{}, error) {
 // ClientProtocol impl.
 func (c *GRPCClient) Ping() error {
 	client := grpc_health_v1.NewHealthClient(c.Conn)
-	_, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+	resp, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
 		Service: GRPCServiceName,
 	})
+	if err != nil {
+		return err
+	}
 
-	return err
+	if resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+		return fmt.Errorf("plugin %q health check returned non-SERVING status: %s", GRPCServiceName, resp.Status)
+	}
+
+	return nil
 }

--- a/grpc_stdio.go
+++ b/grpc_stdio.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"io"
 
-	empty "github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/protobuf/types/known/emptypb"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin/internal/plugin"
 	"google.golang.org/grpc"
@@ -49,7 +49,7 @@ func newGRPCStdioServer(log hclog.Logger, srcOut, srcErr io.Reader) *grpcStdioSe
 
 // StreamStdio streams our stdout/err as the response.
 func (s *grpcStdioServer) StreamStdio(
-	_ *empty.Empty,
+	_ *emptypb.Empty,
 	srv plugin.GRPCStdio_StreamStdioServer,
 ) error {
 	// Share the same data value between runs. Sending this over the wire
@@ -101,7 +101,7 @@ func newGRPCStdioClient(
 	client := plugin.NewGRPCStdioClient(conn)
 
 	// Connect immediately to the endpoint
-	stdioClient, err := client.StreamStdio(ctx, &empty.Empty{})
+	stdioClient, err := client.StreamStdio(ctx, &emptypb.Empty{})
 
 	// If we get an Unavailable or Unimplemented error, this means that the plugin isn't
 	// updated and linking to the latest version of go-plugin that supports

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"github.com/hashicorp/go-hclog"
 	grpctest "github.com/hashicorp/go-plugin/test/grpc"
 	"google.golang.org/grpc"
@@ -285,14 +285,14 @@ func (s *testGRPCServer) Bidirectional(ctx context.Context, req *grpctest.Bidire
 func (s *testGRPCServer) PrintStdio(
 	ctx context.Context,
 	req *grpctest.PrintStdioRequest,
-) (*empty.Empty, error) {
+) (*emptypb.Empty, error) {
 	s.Impl.PrintStdio(req.Stdout, req.Stderr)
-	return &empty.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
-func (s *testGRPCServer) Panic(ctx context.Context, req *grpctest.PanicRequest) (*empty.Empty, error) {
+func (s *testGRPCServer) Panic(ctx context.Context, req *grpctest.PanicRequest) (*emptypb.Empty, error) {
 	err := s.Impl.Panic(req.Message)
-	return &empty.Empty{}, err
+	return &emptypb.Empty{}, err
 }
 
 type pingPongServer struct {


### PR DESCRIPTION
Fixes #341. GRPCClient.Ping only checked whether the RPC call returned an error. A reachable but non-SERVING plugin would pass Ping. Now the response status is validated and an error is returned if it is not SERVING.