### PR TITLE
cmdrunner: release process handle in _pidAlive to avoid pidfd leak

### DIFF
--- a/internal/cmdrunner/process_posix.go
+++ b/internal/cmdrunner/process_posix.go
@@ -16,8 +16,10 @@ func _pidAlive(pid int) bool {
 	proc, err := os.FindProcess(pid)
 	if err == nil {
 		// On Linux with Go 1.23+, FindProcess opens a pidfd which must be
-		// released or it leaks an FD on every call.
-		defer proc.Release()
+		// released or it leaks an FD on every call. Release errors are
+		// intentionally ignored; the handle is short-lived and there's
+		// nothing actionable to recover from a release failure.
+		defer func() { _ = proc.Release() }()
 		err = proc.Signal(syscall.Signal(0))
 	}
 

--- a/internal/cmdrunner/process_posix.go
+++ b/internal/cmdrunner/process_posix.go
@@ -15,6 +15,9 @@ import (
 func _pidAlive(pid int) bool {
 	proc, err := os.FindProcess(pid)
 	if err == nil {
+		// On Linux with Go 1.23+, FindProcess opens a pidfd which must be
+		// released or it leaks an FD on every call.
+		defer proc.Release()
 		err = proc.Signal(syscall.Signal(0))
 	}
 


### PR DESCRIPTION
## Description

`_pidAlive` in `internal/cmdrunner/process_posix.go` calls `os.FindProcess(pid)` and never releases the returned `*os.Process`. On Linux with Go 1.23+ that call now opens a pidfd under the hood (`os.pidfdFind` → `pidfd_open`), so every invocation leaks one file descriptor.

`pidWait` polls once per second per plugin, so the leak scales linearly with plugin count × uptime. In the downstream Nomad report (hashicorp/nomad#27847) a client with a few hundred allocations saw the host-side FD count cycle between 20k and 130k, eventually tripping `EMFILE` and breaking CNI config loads, disk-stats collection, `pipe2`, and docker socket dials.

The fix is a one-liner: `defer proc.Release()` right after the `FindProcess` call, so the pidfd is closed on every return path. The Windows implementation already does the equivalent with `defer syscall.CloseHandle(h)` in `process_windows.go`, so this just brings the POSIX side in line.

Before:
```
pidfd_open(686713, 0) = 90771
pidfd_open(690846, 0) = 90772
pidfd_open(123738, 0) = 90774
...
```
(one new FD per poll iteration per plugin, never closed)

## Related Issue

Downstream report: hashicorp/nomad#27847

## How Has This Been Tested?

- `go build ./...` and `go vet ./...` clean on both host (Windows) and `GOOS=linux`
- `go test ./internal/cmdrunner/...` passes
- Reviewed against the Windows `_pidAlive` which has always done the equivalent cleanup via `defer syscall.CloseHandle(h)`, so behavior is symmetric across platforms

Caching the `*os.Process` on the runner would avoid the repeated `FindProcess` entirely and is probably the better long-term change, but it's a larger refactor touching `Runner` lifecycle. Keeping this PR to the minimal, backport-friendly fix; happy to follow up with the caching variant in a separate PR if preferred.