### PR TITLE
deps: Remove direct use of deprecated github.com/golang/protobuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 SECURITY:
 * deps: Updated google.golang.org/grpc to v1.81.1 [[GH-383](https://github.com/hashicorp/go-plugin/pull/383)]
 
+ENHANCEMENTS:
+* deps: Removed direct use of deprecated `github.com/golang/protobuf` in favour of `google.golang.org/protobuf` [[GH-388](https://github.com/hashicorp/go-plugin/pull/388)]
+
 ## v1.7.0
 
 CHANGES:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/hashicorp/go-plugin
 go 1.25.0
 
 require (
-	github.com/golang/protobuf v1.5.4
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/yamux v0.1.2
 	github.com/jhump/protoreflect v1.18.0
@@ -14,6 +13,7 @@ require (
 
 require (
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/jhump/protoreflect/v2 v2.0.0-beta.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect

--- a/grpc_stdio.go
+++ b/grpc_stdio.go
@@ -9,12 +9,12 @@ import (
 	"context"
 	"io"
 
-	empty "github.com/golang/protobuf/ptypes/empty"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin/internal/plugin"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	empty "google.golang.org/protobuf/types/known/emptypb"
 )
 
 // grpcStdioBuffer is the buffer size we try to fill when sending a chunk of

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -17,10 +17,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/go-hclog"
 	grpctest "github.com/hashicorp/go-plugin/test/grpc"
 	"google.golang.org/grpc"
+	empty "google.golang.org/protobuf/types/known/emptypb"
 )
 
 // Test that NetRPCUnsupportedPlugin implements the correct interfaces.


### PR DESCRIPTION
Closes: https://github.com/hashicorp/go-plugin/issues/338